### PR TITLE
Add Docker entrypoint to handle db migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,14 @@ RUN apk add --update --no-cache bash openssl
 
 WORKDIR /opt/app
 
-COPY --from=builder /opt/built .
-RUN chown -R nobody: .
+COPY --chown=nobody entrypoint.sh /
+COPY --from=builder --chown=nobody /opt/built .
+RUN chown nobody: .
 
 USER nobody
 
 EXPOSE 4000
+
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
 
 CMD trap 'exit' INT; bin/teslamate start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+: ${DATABASE_HOST:='127.0.0.1'}
+
+# wait until the postgres port opens
+sleep 1s
+p=1
+while : ; do
+  set +e
+  (nc -z ${DATABASE_HOST} 5432) >/dev/null 2>&1
+  [[ $? -eq 0 ]] && break
+  set -e
+  p=`expr $p + $p`
+  echo waiting for postgres at ${DATABASE_HOST} \(${p}sec\)
+  sleep ${p}s
+done
+
+# apply migrations
+bin/teslamate eval "TeslaMate.Release.migrate"
+
+exec "$@"


### PR DESCRIPTION
This adds a new entrypoint for the Docker image where the db migration will be applied on container creation. It makes the stack easier to run on Docker swarm.

This also slightly reduces the final Docker image size by using `COPY --chown` command.
`COPY` then `RUN chown -R` takes 2x space for the layer.
(Directory `.` still needs to be `chown`ed for tmp stuff...)

Thank you for your hard work!