### PR TITLE
Removing DATABASE_PORT from docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ services:
     environment:
       - POSTGRES_USER=teslamate
       - POSTGRES_PASSWORD=secret
-    ports:
-      - 5432:5432
     volumes:
       - teslamate-db:/var/lib/postgresql/data
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ services:
       - DATABASE_PASS=secret
       - DATABASE_NAME=teslamate
       - DATABASE_HOST=db
-      - DATABASE_PORT=5432 # Optional, set if services.db.ports is remapped
       - TESLA_USERNAME=username@example.com
       - TESLA_PASSWORD=secret
       - MQTT_HOST=mosquitto


### PR DESCRIPTION
DATABASE_PORT is useful when running manually without docker-compose but
the DATABASE_HOST db is referring to the docker-compose postgres which
is on the network created in the docker-compose.