### PR TITLE
add TZ environment variable to sample docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ services:
       - TESLA_PASSWORD=secret
       - MQTT_HOST=mosquitto
       - VIRTUAL_HOST=localhost # if you're going to access the UI from another machine replace "localhost" with the hostname / IP address of the docker host
+      - TZ="Europe/London"
     ports:
       - 4000:4000
     cap_drop:


### PR DESCRIPTION
If TZ is not set in container Tesla API auth fails