### PR TITLE
Datasource variable on all dashboards

### DIFF
--- a/grafana/dashboards/charge-details.json
+++ b/grafana/dashboards/charge-details.json
@@ -19,6 +19,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -143,6 +144,7 @@
       }
     },
     {
+      "datasource": "$Datasource",
       "autoZoom": true,
       "gridPos": {
         "h": 20,
@@ -196,6 +198,19 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {
           "text": "",
           "value": ""
@@ -220,7 +235,7 @@
           "text": "F",
           "value": "F"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_temperature from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -245,7 +260,7 @@
           "text": "1",
           "value": "1"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 0,
         "includeAll": false,
@@ -276,7 +291,7 @@
           "text": "mi",
           "value": "mi"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -40,6 +40,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -518,12 +519,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -548,7 +562,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -573,7 +587,7 @@
           "text": "C",
           "value": "C"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_temperature from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -40,6 +40,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -153,6 +154,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -266,6 +268,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -375,6 +378,7 @@
       "type": "table"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -475,6 +479,7 @@
       "type": "table"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -596,12 +601,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,

--- a/grafana/dashboards/degradation.json
+++ b/grafana/dashboards/degradation.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -201,12 +202,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -231,7 +245,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/drive-details.json
+++ b/grafana/dashboards/drive-details.json
@@ -11,6 +11,7 @@
         "type": "dashboard"
       },
       {
+        "datasource": "$Datasource",
         "enable": true,
         "hide": false,
         "iconColor": "rgba(255, 96, 96, 1)",
@@ -22,6 +23,7 @@
         "type": "tags"
       },
       {
+        "datasource": "$Datasource",
         "enable": true,
         "hide": false,
         "iconColor": "#508642",
@@ -33,6 +35,7 @@
         "type": "tags"
       },
       {
+        "datasource": "$Datasource",
         "enable": true,
         "hide": false,
         "iconColor": "#64b0c8",
@@ -44,6 +47,7 @@
         "type": "tags"
       },
       {
+        "datasource": "$Datasource",
         "enable": true,
         "hide": false,
         "iconColor": "#ba43a9",
@@ -55,6 +59,7 @@
         "type": "tags"
       },
       {
+        "datasource": "$Datasource",
         "enable": true,
         "hide": false,
         "iconColor": "rgb(158, 154, 154)",
@@ -74,6 +79,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -206,6 +212,7 @@
       }
     },
     {
+      "datasource": "$Datasource",
       "autoZoom": true,
       "gridPos": {
         "h": 28,
@@ -297,6 +304,7 @@
       "type": "pr0ps-trackmap-panel"
     },
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -411,6 +419,7 @@
       }
     },
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -561,6 +570,19 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {
           "text": "",
           "value": ""
@@ -584,7 +606,7 @@
           "text": "C",
           "value": "C"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_temperature from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -609,7 +631,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -635,7 +657,7 @@
           "text": "1",
           "value": "1"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 0,
         "includeAll": false,
@@ -660,7 +682,7 @@
           "text": "m",
           "value": "m"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select case when unit_of_length = 'km' then 'm' when unit_of_length = 'mi' then 'ft' end  from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -687,12 +688,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -717,7 +731,7 @@
           "text": "C",
           "value": "C"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_temperature from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -742,7 +756,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/efficiency.json
+++ b/grafana/dashboards/efficiency.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -152,6 +153,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -264,6 +266,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -376,6 +379,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -579,6 +583,7 @@
       "type": "table"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -686,6 +691,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -800,12 +806,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -830,7 +849,7 @@
           "text": "C",
           "value": "C"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_temperature from settings limit 1;",
         "hide": 2,
         "includeAll": false,
@@ -855,7 +874,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/locations.json
+++ b/grafana/dashboards/locations.json
@@ -19,6 +19,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -211,6 +212,7 @@
       "type": "table"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -321,6 +323,7 @@
       "type": "table"
     },
     {
+      "datasource": "$Datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -341,6 +344,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -458,12 +462,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,

--- a/grafana/dashboards/mileage.json
+++ b/grafana/dashboards/mileage.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -165,12 +166,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -195,7 +209,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/position.json
+++ b/grafana/dashboards/position.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "autoZoom": true,
       "gridPos": {
         "h": 16,
@@ -101,13 +102,26 @@
   "tags": [],
   "templating": {
     "list": [
-     {
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,

--- a/grafana/dashboards/states.json
+++ b/grafana/dashboards/states.json
@@ -39,6 +39,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -151,6 +152,7 @@
       "valueName": "current"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -263,6 +265,7 @@
       "valueName": "avg"
     },
     {
+      "datasource": "$Datasource",
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -375,6 +378,7 @@
       "valueName": "current"
     },
     {
+      "datasource": "$Datasource",
       "backgroundColor": "rgba(128,128,128,0.1)",
       "colorMaps": [
         {
@@ -565,12 +569,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,

--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -19,6 +19,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -39,6 +40,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -160,13 +162,26 @@
   "tags": [],
   "templating": {
     "list": [
-     {
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,

--- a/grafana/dashboards/vampire-drain.json
+++ b/grafana/dashboards/vampire-drain.json
@@ -19,6 +19,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -40,6 +41,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "columns": [],
       "fontSize": "100%",
       "gridPos": {
@@ -355,12 +357,25 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,
@@ -438,7 +453,7 @@
           "text": "km",
           "value": "km"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "select unit_of_length from settings limit 1;",
         "hide": 2,
         "includeAll": false,

--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -19,6 +19,7 @@
   "links": [],
   "panels": [
     {
+      "datasource": "$Datasource",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -40,6 +41,7 @@
       "type": "row"
     },
     {
+      "datasource": "$Datasource",
       "autoZoom": true,
       "gridPos": {
         "h": 21,
@@ -100,13 +102,26 @@
   "tags": [],
   "templating": {
     "list": [
-     {
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Teslamate DB",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "postgres",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "text": "All",
           "value": "$__all"
         },
-        "datasource": null,
+        "datasource": "$Datasource",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
         "hide": 2,
         "includeAll": true,


### PR DESCRIPTION
Currently the Grafana dashboards don't specify a datasource, so when imported they use the default. This is fine for new installations off of the docker compose file, however in my situation (and I'm sure for others) I had other data sources already defined in my Grafana installation. This changes adds a variable to each dashboard that will allow users to pick which Postgres datasource to use, if they only have one it will default to that and should function exactly the same as it does before this change.