### PR TITLE
Merge 20191117042320_add_cost_field_to_charges.exs (Charge Cost field)

### DIFF
--- a/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
+++ b/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
@@ -8,3 +8,4 @@ defmodule TeslaMate.Repo.Migrations.AddCostFieldToCharges do
     end
 
   end
+end

--- a/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
+++ b/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
@@ -2,10 +2,8 @@ defmodule TeslaMate.Repo.Migrations.AddCostFieldToCharges do
   use Ecto.Migration
 
   def change do
-
     alter table(:charging_processes) do
       add(:cost, :decimal, precision: 6, scale: 2)
     end
-
   end
 end

--- a/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
+++ b/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
@@ -3,8 +3,8 @@ defmodule TeslaMate.Repo.Migrations.AddCostFieldToCharges do
 
   def change do
 
-    alter table(:charges) do
-      add(:cost, :decimal(6,2))
+    alter table(:charging_processes) do
+      add(:cost, :decimal, precision: 6, scale: 2)
     end
 
   end

--- a/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
+++ b/priv/repo/migrations/20191117042320_add_cost_field_to_charges.exs
@@ -1,0 +1,10 @@
+defmodule TeslaMate.Repo.Migrations.AddCostFieldToCharges do
+  use Ecto.Migration
+
+  def change do
+
+    alter table(:charges) do
+      add(:cost, :decimal(6,2))
+    end
+
+  end


### PR DESCRIPTION
Hi @adriankumpf,

Off the back of the feature request for adding costs to charging details, I wanted to see if I could propose a new database column for this.

I'm new to making a schema change this way so appreciate any feedback. Once I work out how it works, I'll update the development doco to explain the process.

I have modeled this on other schema changes I can see in the distribution, however I couldn't find an example of a datatype with arguments in the way that I have defined this one, and I am not sure how to make these migrations apply to my existing distribution, I have tried restarting teslamate but that doesn't seem to initiate it.

The reasoning for the datatype proposed is:

   * floating point datatypes are imprecise
   * whilst integer could be used for representing cents, it would require a conversion routine for this which might differ per currency based on localisation - not sure if that is just adding unnecessary complexity?
   * decimal(6,2) gives 6 digits in total with a 2 digit exact decimal precision. This would support a number up to 9999.99 or 999999. It is somewhat of an assumption that this will be sufficient for all currencies however it doesn't seem unreasonable to me in that currencies with high values will generally not involve decimal precision. Do you think it is sufficient, or would a larger field size (say 12,2) be a safer bet?

Once I know how best to test this, I'll test it on my distribution. Let me know if you would like me to approach this in a different way.