### PR TITLE
Update simple docker documentation

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -40,6 +40,7 @@ services:
     environment:
       - POSTGRES_USER=teslamate
       - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=teslamate
     volumes:
       - teslamate-db:/var/lib/postgresql/data
 


### PR DESCRIPTION
add `POSTGRES_DB` parameter. If not specified, this name is taken from `POSTGRES_USER` which only works as long as the username equals the database name in the teslamate/grafana configs.