### PR TITLE
Correct typos in projected-range.json

### DIFF
--- a/grafana/dashboards/projected-range.json
+++ b/grafana/dashboards/projected-range.json
@@ -157,7 +157,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Projected Range - Milage",
+      "title": "Projected Range - Mileage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -184,7 +184,7 @@
         {
           "decimals": null,
           "format": "none",
-          "label": "Milage",
+          "label": "Mileage",
           "logBase": 1,
           "max": null,
           "min": null,


### PR DESCRIPTION
Corrected typo in word 'milage'