### PR TITLE
update docs to include wake proxy example for apache

### DIFF
--- a/docs/configuration/guides/shortcuts.md
+++ b/docs/configuration/guides/shortcuts.md
@@ -8,8 +8,8 @@ Unfortunately, only couple of the useful events (like NFC on NFC enabled phones)
 
 These values are used in the screenshots. Whenever you see them, replace them with the actual values used on your system.
 
-- Your wake up endpoint is exposed at: **https://teslamate.example.com/wake** and proxied to something like `http://teslamate:4000/api/car/$car_id/logging/resume` where `$car_id` is 1 if you have only one car. (see [Advanced Docker Setup - Apache2](../../installation/docker_advanced_apache.md) for an example)
-- The Endpoint is protected by **Basic Authentication** with the user **mylogin** and password **mysecretpassword**. Note that this **IS NOT** your Tesla password.
+- Your TeslaMate instance is exposed at `https://teslamate.example.com`.
+- The endpoint is protected by **Basic Authentication** with the user **mylogin** and password **mysecretpassword**. Note that this **IS NOT** your Tesla password.
 
 ## Setup the automation
 
@@ -48,7 +48,7 @@ These values are used in the screenshots. Whenever you see them, replace them wi
 - Click the **+** icon below the actions. This brings you to the list of available actions.
 - Click the gray **X** to close Scripting category.
 - Select **Web** (cyan icon), go to **URLs** block and select **URL**.
-- Type in your endpoint public URL e.g. `https://mytm.myweb.com/wake`
+- Type in your endpoint public URL e.g. `https://teslamate.example.com/api/car/$car_id/logging/resume` where `$car_id` is 1 if there is only one car.
 
 ![](../../images/shortcuts/create_15_enc_added.png) ![](../../images/shortcuts/create_16_scripting_close.png) ![](../../images/shortcuts/create_17_action_categories.png)
 ![](../../images/shortcuts/create_17_url.png)
@@ -88,7 +88,6 @@ These values are used in the screenshots. Whenever you see them, replace them wi
 
 ## Running the Automation
 
-- Get into the car and wake it up by pressing the brake pedal (if needed).
 - Once the Bluetooth connects, you will see notification on your lock screen.
 - Click **Run** button.
 - Done.

--- a/docs/configuration/guides/shortcuts.md
+++ b/docs/configuration/guides/shortcuts.md
@@ -8,7 +8,7 @@ Unfortunately, only couple of the useful events (like NFC on NFC enabled phones)
 
 These values are used in the screenshots. Whenever you see them, replace them with the actual values used on your system.
 
-- Your wake up endpoint is exposed at: **https://teslamate.example.com/wake** and proxied to something like `http://teslamate:4000/api/car/$car_id/logging/resume` where `$car_id` is 1 if you have only one car.
+- Your wake up endpoint is exposed at: **https://teslamate.example.com/wake** and proxied to something like `http://teslamate:4000/api/car/$car_id/logging/resume` where `$car_id` is 1 if you have only one car. (see [Advanced Docker Setup - Apache2](../../installation/docker_advanced_apache.md) for an example)
 - The Endpoint is protected by **Basic Authentication** with the user **mylogin** and password **mysecretpassword**. Note that this **IS NOT** your Tesla password.
 
 ## Setup the automation

--- a/docs/installation/docker_advanced_apache.md
+++ b/docs/installation/docker_advanced_apache.md
@@ -182,32 +182,3 @@ Start the stack with `docker-compose up` run in the same directory, where the do
 1. Open the web interface [https://teslamate.example.com](https://teslamate.example.com)
 2. Sign in with your Tesla account
 3. The Grafana dashboards are available at [https://grafana.example.com](https://grafana.example.com).
-
-## Proxying /wake Endpoint
-
-Replace the teslamate section of your apache configuration with the block below. (This assumes you have a single car set up!)
-
-```apacheconf
-<IfModule mod_ssl.c>
-    <VirtualHost *:443>
-        ProxyPreserveHost On
-        ServerName teslamate.${MYDOMAIN}
-        ProxyPass /live/websocket ws://127.0.0.1:4000/live/websocket
-        ProxyPassReverse /live/websocket ws://127.0.0.1:4000/live/websocket
-        ProxyPass /wake http://127.0.0.1:4000/api/car/1/logging/resume
-        ProxyPassReverse /wake http://127.0.0.1:4000/api/car/1/logging/resume
-        ProxyPass / http://127.0.0.1:4000/
-        ProxyPassReverse / http://127.0.0.1:4000/
-        CustomLog /var/log/apache2/${LOG} combined
-        <Proxy *>
-            Authtype Basic
-            Authname "Password Required"
-            AuthUserFile /etc/apache2/.htpasswd
-            Require valid-user
-        </Proxy>
-        SSLCertificateFile /etc/letsencrypt/live/teslamate.${MYDOMAIN}/fullchain.pem
-        SSLCertificateKeyFile /etc/letsencrypt/live/teslamate.${MYDOMAIN}/privkey.pem
-        Include /etc/letsencrypt/options-ssl-apache.conf
-    </VirtualHost>
-</IfModule>
-```


### PR DESCRIPTION
Just finished setting this up from scratch and it was hard to tell you actually needed to set this up if you didn't read the docs to carefully. I looked through the docs for traefik to see if there was an easy label to set for the http router to proxy this as well but didn't see anything obvious. If someone wants to add that, it would also be useful and I imagine most people would like this enabled by default.

As a side note it looks like the docs for the wake integration are pretty different as the ios docs are the only ones that mention proxy'ing an endpoint like this. 