### PR TITLE
[ISSUE-434] Increase charge cost scale / kWh

### DIFF
--- a/lib/teslamate_web/templates/geo_fence/form.html.leex
+++ b/lib/teslamate_web/templates/geo_fence/form.html.leex
@@ -72,8 +72,8 @@
       <div class="field">
         <div class="control">
           <%= text_input f, :cost_per_kwh, class: "input",
-                             type: :number, inputmode: :decimal, min: 0.0, step: 0.01,
-                             placeholder: "0.00",
+                             type: :number, inputmode: :decimal, min: 0.0, step: 0.0001,
+                             placeholder: "0.0000",
                              phx_hook: "SetLangAttr"
           %>
         </div>

--- a/priv/repo/migrations/20200212001245_location_based_charge_cost_increase_scale.exs
+++ b/priv/repo/migrations/20200212001245_location_based_charge_cost_increase_scale.exs
@@ -1,0 +1,9 @@
+defmodule TeslaMate.Repo.Migrations.LocationBasedChargeCostIncreaseScale do
+  use Ecto.Migration
+
+  def change do
+    alter table(:geofences) do
+      modify(:cost_per_kwh, :decimal, precision: 6, scale: 4)
+    end
+  end
+end

--- a/test/teslamate/locations/geofences_test.exs
+++ b/test/teslamate/locations/geofences_test.exs
@@ -17,7 +17,7 @@ defmodule TeslaMate.LocationsGeofencesTest do
       latitude: 53.514521,
       longitude: 14.350144,
       radius: 43,
-      cost_per_kwh: 0.79
+      cost_per_kwh: 0.0079
     }
     @invalid_attrs %{
       name: nil,
@@ -268,7 +268,7 @@ defmodule TeslaMate.LocationsGeofencesTest do
       assert geofence.latitude == 53.514521
       assert geofence.longitude == 14.350144
       assert geofence.radius == 43
-      assert geofence.cost_per_kwh == Decimal.from_float(0.79)
+      assert geofence.cost_per_kwh == Decimal.from_float(0.0079)
       assert geofence.sleep_mode_blacklist == [car]
       assert geofence.sleep_mode_whitelist == [car]
 

--- a/test/teslamate/log/log_charging_test.exs
+++ b/test/teslamate/log/log_charging_test.exs
@@ -400,7 +400,7 @@ defmodule TeslaMate.LogChargingTest do
 
       assert cproc.charge_energy_added == 12.77
       assert cproc.charge_energy_used == 12.455230833333333
-      assert cproc.cost == Decimal.new("3.11380770833333325")
+      assert cproc.cost == Decimal.new("3.1138077083333332500")
     end
 
     test "charge cost can be zero" do
@@ -426,7 +426,7 @@ defmodule TeslaMate.LogChargingTest do
 
       assert cproc.charge_energy_added == nil
       assert cproc.charge_energy_used == 12.576319999999997
-      assert cproc.cost == Decimal.new("0E-17")
+      assert cproc.cost == Decimal.new("0E-19")
     end
 
     test "sets charge cost to zero if free supercharging is enabled" do


### PR DESCRIPTION
@adriankumpf - I had a few things to fix on my Mac, all done and got my dev env up & running.

Before making my changes, I added a geo-fence location with a cost price of 0.05

I made my changes and the database modify automatically reflected the adjustment from "0.05" to "0.0500".

```teslamate_dev=# select * from geofences;
 id | name | latitude | longitude | radius |     inserted_at     |     updated_at      | cost_per_kwh
----+------+----------+-----------+--------+---------------------+---------------------+--------------
  1 | test |        0 |         0 |     20 | 2020-02-12 06:12:17 | 2020-02-12 06:12:17 |       0.0500
```

 I was required to adjust some values in `test/teslamate/log/log_charging_test.exs` - I'm no Exilir pro, ... please double check my changes.