### PR TITLE
Documentation fix for upgrading manual installs

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -21,7 +21,7 @@
 
    ```bash
    git pull
-   git checkout $(git describe --tags)
+   git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 
    mix deps.get --only prod
    npm install --prefix ./assets && npm run deploy --prefix ./assets

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -35,4 +35,8 @@
     _build/prod/rel/teslamate/bin/teslamate eval "TeslaMate.Release.migrate"
    ```
 
-4. Finally, re-import the dashboards.
+4. Finally, re-import the Grafana dashboards:
+
+   ```bash
+   LOGIN="user:pass" ./grafana/dashboards.sh restore
+    ```


### PR DESCRIPTION
The existing documentation doesn't work, this fix actually checks out the latest available tag.