### PR TITLE
Add Title to Grafana table to allow sorting

### DIFF
--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -1718,7 +1718,7 @@
           ]
         }
       ],
-      "title": "",
+      "title": "Drives",
       "transform": "table",
       "type": "table"
     },


### PR DESCRIPTION
I was trying to sort my trips by distance on the Trip dashboard while seeing the total distance for a set period. 
I know I could've went to the Drives dashboard to do the sorting, but I felt like it would be nice to be able to do it in the Trip dashboard since I was already in it.