### PR TITLE
Add tini to Dockerfile and use it as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV LANG=C.UTF-8 \
     SRTM_CACHE=/opt/app/.srtm_cache \
     HOME=/opt/app
 
-RUN apk add --update --no-cache bash openssl tzdata
+RUN apk add --update --no-cache bash tini openssl tzdata
 
 WORKDIR $HOME
 RUN chown -R nobody: .
@@ -44,5 +44,5 @@ RUN mkdir .srtm_cache
 
 EXPOSE 4000
 
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/sh", "/entrypoint.sh"]
 CMD ["bin/teslamate", "start"]


### PR DESCRIPTION
This change adds [`tini`](https://github.com/krallin/tini) as the `init` process for the Teslamate Docker container. The reason for this is that currently the container runs with zombie processes.

This means the current process with PID=1 in the container doesn't reap children properly and given the output I get while fixing this, child processes are dying accidentally.

There's also an option to work around this with docker-compose since compose file version 3.7, which allows passing `--init` for the docker container. I'm currently using that to work around the zombie processes, but adding `tini` fixes this independent of how people run this container.

https://github.com/krallin/tini#why-tini has more explanation as to why it's useful to use it as PID=1 instead of the Erlang VM in this specific case.

Before using a different init, this is what I see locally here:

```
root      522809  0.0  0.0 109980  5148 ?        Sl   09:54   0:00  \_ containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/x -address 
nobody    522874  112  0.1 1266124 128176 ?      Ssl  09:54   0:07      \_ /opt/app/erts-10.7/bin/beam.smp -- -root /opt/app -progname erl -- -home /opt/app -- -noshell -s elixir start_cli -mode embedded -setcookie X
nobody    523098  0.0  0.0      0     0 ?        Zs   09:54   0:00          \_ [epmd] <defunct>
nobody    523099  0.0  0.0    840    36 ?        S    09:54   0:00          \_ /opt/app/erts-10.7/bin/epmd -daemon
nobody    523103  2.5  0.0    768     4 ?        Ss   09:54   0:00          \_ erl_child_setup 1048576
nobody    523141  0.0  0.0      0     0 ?        Z    09:54   0:00          \_ [inet_gethost] <defunct>
```

The zombie processes are visible here. After using `init: true` in my docker-compose locally (I have a new enough version that supports 3.7), it looks like:

```
root      524088  0.0  0.0 108700  5208 ?        Sl   09:57   0:00  \_ containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/x -address 
nobody    524112  0.1  0.0   1104     4 ?        Ss   09:57   0:00      \_ /sbin/docker-init -- /bin/sh /entrypoint.sh bin/teslamate start
nobody    524204 14.1  0.2 1295668 171140 ?      Sl   09:57   0:09          \_ /opt/app/erts-10.7/bin/beam.smp -- -root /opt/app -progname erl -- -home /opt/app -- -noshell -s elixir start_cli -mode embedded -setcookie x
nobody    524392  0.1  0.0    768     4 ?        Ss   09:58   0:00          |   \_ erl_child_setup 1048576
nobody    524459  0.0  0.0    800     4 ?        Ss   09:58   0:00          |       \_ inet_gethost 4
nobody    524460  0.0  0.0    800    32 ?        S    09:58   0:00          |           \_ inet_gethost 4
nobody    524388  0.0  0.0    840    36 ?        S    09:58   0:00          \_ /opt/app/erts-10.7/bin/epmd -daemon
```

No zombie processes anymore :smile:. 

With change, it would show `tini` instead of `docker-init`, but the end result is the same and that way it's independent of the version of Docker that someone has, whether they pass `--init` or have to do something else in case of for example Kubernetes.