### PR TITLE
Add Python to build phase.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM elixir:1.10-alpine AS builder
 
-RUN apk add --update --no-cache nodejs npm git build-base && \
+RUN apk add --update --no-cache nodejs npm git build-base python && \
     mix local.rebar --force && \
     mix local.hex --force
 


### PR DESCRIPTION
Without adding Python, it's showing a big warning message when running `node-gyp`:

```
> fsevents@1.2.12 install /opt/app/assets/node_modules/watchpack/node_modules/fsevents
> node-gyp rebuild

gyp ERR! find Python
gyp ERR! find Python Python is not set from command line or npm configuration
gyp ERR! find Python Python is not set from environment variable PYTHON
gyp ERR! find Python checking if "python" can be used
gyp ERR! find Python - "python" is not in PATH or produced an error
gyp ERR! find Python checking if "python2" can be used
gyp ERR! find Python - "python2" is not in PATH or produced an error
gyp ERR! find Python checking if "python3" can be used
gyp ERR! find Python - "python3" is not in PATH or produced an error
gyp ERR! find Python
gyp ERR! find Python **********************************************************
gyp ERR! find Python You need to install the latest version of Python.
gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
gyp ERR! find Python you can try one of the following options:
gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
gyp ERR! find Python   (accepted by both node-gyp and npm)
gyp ERR! find Python - Set the environment variable PYTHON
gyp ERR! find Python - Set the npm configuration variable python:
gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
gyp ERR! find Python For more information consult the documentation at:
gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
gyp ERR! find Python **********************************************************
gyp ERR! find Python
gyp ERR! configure error
gyp ERR! stack Error: Could not find any Python installation to use
gyp ERR! stack     at PythonFinder.fail (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:307:47)
gyp ERR! stack     at PythonFinder.runChecks (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:136:21)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:179:16)
gyp ERR! stack     at PythonFinder.execFileCallback (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:271:16)
gyp ERR! stack     at exithandler (child_process.js:302:5)
gyp ERR! stack     at ChildProcess.errorhandler (child_process.js:314:5)
gyp ERR! stack     at ChildProcess.emit (events.js:223:5)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:270:12)
gyp ERR! stack     at onErrorNT (internal/child_process.js:456:16)
gyp ERR! stack     at processTicksAndRejections (internal/process/task_queues.js:81:21)
gyp ERR! System Linux 4.19.76-linuxkit
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /opt/app/assets/node_modules/watchpack/node_modules/fsevents
gyp ERR! node -v v12.15.0
gyp ERR! node-gyp -v v5.0.5
gyp ERR! not ok
```

Adding python to the build container fixes this error. I'm not sure if this is a real issue, but might be worth fixing such a fairly scary warning when building the Docker container?