### PR TITLE
Charging indicator tweak

### DIFF
--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -98,11 +98,11 @@
                 },
                 {
                   "color": "semi-dark-yellow",
-                  "value": 80
+                  "value": 81
                 },
                 {
                   "color": "light-red",
-                  "value": 90
+                  "value": 91
                 }
               ]
             },


### PR DESCRIPTION
Charging piechart indicator: yellow from 81%, red from 91%.

I charge my car to 80% during these pandemic times, and 90% usually. There's nothing inherent bad at charging to 80% so why not keep it green, or charging to 90% which is at the best practice limit and keep it yellow. I'd prefer the indicator switches to yellow at 81% and red at 91%.