### PR TITLE
Ensure dashboards are restored into the same folder as they currently belong to

### DIFF
--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -60,8 +60,7 @@ backup() {
 restore() {
   find "$DASHBOARDS_DIRECTORY" -type f -name \*.json -print0 |
       while IFS= read -r -d '' dashboard_path; do
-          dashboard=$(basename "$dashboard_path" .json)
-          folder_id=$(get_folder_id "$dashboard")
+          folder_id=$(get_folder_id "$(basename "$dashboard_path" .json)")
           curl \
             --silent --show-error --output /dev/null \
             --user "$LOGIN" \
@@ -75,7 +74,7 @@ restore() {
                                  \"value\":\"TeslaMate\"}]}" \
             "$URL/api/dashboards/import"
 
-        echo "RESTORED $(basename "$dashboard_path")"
+          echo "RESTORED $(basename "$dashboard_path")"
       done
 }
 

--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -18,6 +18,7 @@ readonly URL=${URL:-"http://localhost:3000"}
 readonly LOGIN=${LOGIN:-"admin:admin"}
 readonly DASHBOARDS_DIRECTORY=${DASHBOARDS_DIRECTORY:-"./grafana/dashboards"}
 
+
 main() {
   local task=$1
 


### PR DESCRIPTION
~added optional env variable `FOLDER_UID` to support restoring dashboards into a specific Grafana folder, instead of 'General' by default.~