### PR TITLE
Allow configuration of base MQTT topic (defaulting to `teslamate`)

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -83,7 +83,7 @@ if System.get_env("DISABLE_MQTT") != "true" do
     password: System.get_env("MQTT_PASSWORD"),
     tls: System.get_env("MQTT_TLS"),
     accept_invalid_certs: System.get_env("MQTT_TLS_ACCEPT_INVALID_CERTS"),
-    namespace: System.get_env("MQTT_NAMESPACE") |> Util.validate_namespace!()
+    namespace: System.get_env("MQTT_NAMESPACE", "teslamate") |> Util.validate_namespace!()
 end
 
 config :logger,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -5,16 +5,6 @@ defmodule Util do
     :crypto.strong_rand_bytes(length) |> Base.encode64() |> binary_part(0, length)
   end
 
-  def validate_namespace!(nil), do: nil
-  def validate_namespace!(""), do: nil
-
-  def validate_namespace!(ns) when is_binary(ns) do
-    case String.contains?(ns, "/") do
-      true -> raise "MQTT_NAMESPACE must not contain '/'"
-      false -> ns
-    end
-  end
-
   def parse_check_origin!("true"), do: true
   def parse_check_origin!("false"), do: false
   def parse_check_origin!(hosts) when is_binary(hosts), do: String.split(hosts, ",")
@@ -83,7 +73,7 @@ if System.get_env("DISABLE_MQTT") != "true" do
     password: System.get_env("MQTT_PASSWORD"),
     tls: System.get_env("MQTT_TLS"),
     accept_invalid_certs: System.get_env("MQTT_TLS_ACCEPT_INVALID_CERTS"),
-    namespace: System.get_env("MQTT_NAMESPACE", "teslamate") |> Util.validate_namespace!()
+    namespace: System.get_env("MQTT_NAMESPACE", "teslamate")
 end
 
 config :logger,

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -76,7 +76,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
 
   defp publish({key, value}, %State{car_id: car_id, namespace: namespace, deps: deps}) do
     topic =
-      ["teslamate", namespace, "cars", car_id, key]
+      [namespace, "cars", car_id, key]
       |> Enum.reject(&is_nil(&1))
       |> Enum.join("/")
 

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -5,7 +5,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   alias TeslaMate.Vehicles.Vehicle.Summary
   alias TeslaMate.Locations.GeoFence
 
-  defp start_subscriber(name, car_id, namespace \\ nil) do
+  defp start_subscriber(name, car_id, namespace \\ "teslamate") do
     publisher_name = :"mqtt_publisher_#{name}"
     vehicles_name = :"vehicles_#{name}"
 
@@ -149,7 +149,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
   end
 
   test "allows namespaces", %{test: name} do
-    {:ok, pid} = start_subscriber(name, 0, "account_0")
+    {:ok, pid} = start_subscriber(name, 0, "teslamate/account_0")
 
     assert_receive {VehiclesMock, {:subscribe_to_summary, 0}}
 

--- a/test/teslamate/vehicles/vehicle_sync_test.exs
+++ b/test/teslamate/vehicles/vehicle_sync_test.exs
@@ -17,7 +17,7 @@ defmodule TeslaMate.Vehicles.VehicleSyncTest do
          [
            name: name,
            car_id: car_id,
-           namespace: nil,
+           namespace: "teslamate",
            deps_publisher: {MqttPublisherMock, publisher_name}
          ]}
       )


### PR DESCRIPTION
Implements #709.

*NOTE* Breaking change for anyone with an explicit `MQTT_NAMESPACE` defined. They would need to prepend with `teslamate/` to ensure values are published to the same topics as currently.

Shouldn't effect anyone who doesn't use `MQTT_NAMESPACE`.