### PR TITLE
Update of upgrade-documentation

### DIFF
--- a/website/docs/upgrading.mdx
+++ b/website/docs/upgrading.mdx
@@ -23,11 +23,14 @@ values={[
 ]}>
 <TabItem value="docker">
 
-Pull the new images and restart the stack:
+Pull the new images:
 
 ```bash
 docker-compose pull
-docker-compose up
+```
+and restart the stack with `docker-compose up`. To run the containers in the background add the `-d` flag:
+```bash
+docker-compose up -d
 ```
 
 </TabItem>


### PR DESCRIPTION
added "docker-compose up -d" as default for bringing containers up after upgrade (to match the description of installation-documentation).