### PR TITLE
Tweak some Dutch translations

### DIFF
--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -141,7 +141,7 @@ msgstr "Geo-hek \"%{name}\" aangemaakt"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:4 lib/teslamate_web/live/geofence_live/index.ex:22
 #: lib/teslamate_web/live/geofence_live/index.html.leex:4 lib/teslamate_web/templates/layout/root.html.leex:56
 msgid "Geo-Fences"
-msgstr "Geo-Hekken"
+msgstr "Geofences"
 
 #, elixir-format
 #: lib/teslamate_web/live/settings_live/index.html.leex:49
@@ -571,10 +571,10 @@ msgstr "Deuren zijn open"
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.ex:136
 msgid "Trunk is open"
-msgstr "Kofferklep is open"
+msgstr "Kofferbak is open"
 
 #, elixir-format
 #: lib/teslamate_web/live/charge_live/cost.html.leex:112
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
-msgstr ""
+msgstr "Per minuut"


### PR DESCRIPTION
Tweaked some of the Dutch translations (and added the new translation that was missing):

* `Geo-Fences`: Has no Dutch equivalent., just removed the `-` to make it "Dutch"
* `Trunk`: We call that the "kofferbak"
* `Per Minute`: Was missing so added that