### PR TITLE
Allow zoom controls in car live view

### DIFF
--- a/lib/teslamate_web/live/car_live/summary.html.leex
+++ b/lib/teslamate_web/live/car_live/summary.html.leex
@@ -1,6 +1,6 @@
 <div class="car card">
   <div class="card-image">
-    <figure id="map_<%= @car.id %>_container" data-id="<%= @car.id %>" data-marker="arrow" phx-hook="SimpleMap" phx-update="ignore">
+    <figure id="map_<%= @car.id %>_container" data-id="<%= @car.id %>" data-zoom="1" data-marker="arrow" phx-hook="SimpleMap" phx-update="ignore">
       <div id="map_<%= @car.id %>" class="map" style="height: 175px; position: relative;">
         <div class="spinner">
           <span class="is-loading"/>


### PR DESCRIPTION
Addresses #921 

Copied `data-zoom="1"` from https://github.com/adriankumpf/teslamate/blob/master/lib/teslamate_web/live/charge_live/cost.html.leex#L17 which seems to enable zooming according to the JS code https://github.com/adriankumpf/teslamate/blob/master/assets/js/hooks.js#L162

(I have not tested this locally since I don't have a dev environment set up)