### PR TITLE
Fix tooltips in car overview being hidden by .card

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -76,6 +76,7 @@ nav.navbar {
   display: flex;
   flex-direction: column;
   margin-bottom: 25px;
+  overflow: visible;
 
   .card-content {
     padding: 0.8rem 0.4rem;


### PR DESCRIPTION
As mentioned in https://github.com/adriankumpf/teslamate/issues/943#issuecomment-703233419 the tooltips weren't visible in the car overview.

Setting `overflow: visible` on `.car` is a workaround, there might be a better way, but it doesn't seem to break anything and it works.