### PR TITLE
Display update version in the homescreen update tooltip

### DIFF
--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -11,7 +11,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     speed outside_temp inside_temp is_climate_on is_preconditioning locked sentry_mode
     plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open doors_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
-    charger_actual_current charger_voltage version update_available is_user_present geofence
+    charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation
   )a
 
@@ -113,7 +113,8 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       frunk_open: frunk_open(vehicle),
       is_user_present: get_in_struct(vehicle, [:vehicle_state, :is_user_present]),
       version: version(vehicle),
-      update_available: update_available(vehicle)
+      update_available: update_available(vehicle),
+      update_version: update_version(vehicle)
     }
   end
 
@@ -175,6 +176,13 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     case get_in_struct(vehicle, [:vehicle_state, :software_update, :status]) do
       status when status in ["available", "downloading", "downloading_wifi_wait"] -> true
       status when is_binary(status) -> false
+      nil -> nil
+    end
+  end
+
+  defp update_version(vehicle) do
+    case get_in_struct(vehicle, [:vehicle_state, :software_update, :version]) do
+      version when is_binary(version) -> List.first(String.split(version, " "))
       nil -> nil
     end
   end

--- a/lib/teslamate_web/live/car_live/summary.html.leex
+++ b/lib/teslamate_web/live/car_live/summary.html.leex
@@ -71,7 +71,7 @@
         </span>
       <% end %>
       <%= if @summary.update_available do %>
-        <span class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile" data-tooltip='<%= gettext "Software Update available" %>'>
+        <span class="icon has-text-grey-dark has-tooltip-top has-tooltip-left-mobile" data-tooltip='<%= gettext "Software Update available (%{version})", version: @summary.update_version %>'>
           <span class="mdi mdi-gift-outline"></span>
         </span>
       <% end %>

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "Fører tilstede"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "afbryd forsøg på at sove"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "forsøg at sove"
 
@@ -320,11 +320,6 @@ msgstr "Udetemperatur"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "Version"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Softwareopdatering tilgængelig"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr "Bagklap åben"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Softwareopdatering tilgængelig (%{version})"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "Fahrer anwesend"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "Schlafversuch abbrechen"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "versuchen zu schlafen"
 
@@ -320,11 +320,6 @@ msgstr "Außentemperatur"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr ""
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Software Update verfügbar"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr "Kofferraum is geöffnet"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr "Pro Minute"
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Software Update verfügbar (%{version})"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -220,12 +220,12 @@ msgid "Driver present"
 msgstr ""
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr ""
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr ""
 
@@ -318,11 +318,6 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.leex:277
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
-msgstr ""
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
 msgstr ""
 
 #, elixir-format
@@ -576,4 +571,9 @@ msgstr ""
 #: lib/teslamate_web/live/charge_live/cost.html.leex:112
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
+msgstr ""
+
+#, elixir-format
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr ""
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr ""
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr ""
 
@@ -319,11 +319,6 @@ msgstr ""
 #: lib/teslamate_web/live/car_live/summary.html.leex:277
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
-msgstr ""
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
 msgstr ""
 
 #, elixir-format
@@ -577,4 +572,9 @@ msgstr ""
 #: lib/teslamate_web/live/charge_live/cost.html.leex:112
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "Conductor presente"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "cancelar intento de poner en estado reposo"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "intentando poner en estado reposo"
 
@@ -320,11 +320,6 @@ msgstr "Temperatura en el exterior"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "Versión"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Actualización de software disponible"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr ""
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Actualización de software disponible (%{version})"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -220,12 +220,12 @@ msgid "Driver present"
 msgstr "Conducteur présent"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "Annuler la tentative de sommeil"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "Tentative de mise en veille"
 
@@ -319,11 +319,6 @@ msgstr "Température extérieure"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "Version"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Mise à jour disponible"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -577,3 +572,8 @@ msgstr "Le coffre est ouvert"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Mise à jour disponible (%{version})"

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "현재 운전자"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "절전모드 시도 취소"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "절전모드 시도"
 
@@ -320,11 +320,6 @@ msgstr "실외 온도"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "소프트웨어 버전"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "소프트웨어 업데이트 가능"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr "트렁크가 열려있습니다."
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "소프트웨어 업데이트 가능 (%{version})"

--- a/priv/gettext/nb/LC_MESSAGES/default.po
+++ b/priv/gettext/nb/LC_MESSAGES/default.po
@@ -222,12 +222,12 @@ msgid "Driver present"
 msgstr "Fører er tilstede"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "Avbryt dvale"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "forsøk på dvale"
 
@@ -321,11 +321,6 @@ msgstr "Temperatur utvendig"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "Software versjon"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Ny software tilgjengelig"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -579,3 +574,8 @@ msgstr "Bagasjeluken er åpen"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Ny software tilgjengelig (%{version})"

--- a/priv/gettext/nl/LC_MESSAGES/default.po
+++ b/priv/gettext/nl/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "Bestuurder aanwezig"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "annuleer slaap-poging"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "probeer te slapen"
 
@@ -320,11 +320,6 @@ msgstr "Buitentemperatuur"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "Versie"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Software-update beschikbaar"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr "Kofferbak is open"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr "Per minuut"
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Software-update beschikbaar (%{version})"

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -221,12 +221,12 @@ msgid "Driver present"
 msgstr "Förare närvarande"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "avbryt försök att vila"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "försök att vila"
 
@@ -320,11 +320,6 @@ msgstr "Utetemperatur"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr ""
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "Mjukvaruuppdatering tillgänglig"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -578,3 +573,8 @@ msgstr "Bakluckan är öppen"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "Mjukvaruuppdatering tillgänglig (%{version})"

--- a/priv/gettext/zh_Hans/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hans/LC_MESSAGES/default.po
@@ -222,12 +222,12 @@ msgid "Driver present"
 msgstr "当前驾驶员"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "取消休眠"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "尝试休眠"
 
@@ -321,11 +321,6 @@ msgstr "车外温度"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "当前固件版本"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "有可用更新"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -579,3 +574,8 @@ msgstr "行李箱已打开"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "有可用更新 (%{version})"

--- a/priv/gettext/zh_Hant/LC_MESSAGES/default.po
+++ b/priv/gettext/zh_Hant/LC_MESSAGES/default.po
@@ -220,12 +220,12 @@ msgid "Driver present"
 msgstr "駕駛中"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:298
+#: lib/teslamate_web/live/car_live/summary.html.leex:297
 msgid "cancel sleep attempt"
 msgstr "取消休眠"
 
 #, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:293
+#: lib/teslamate_web/live/car_live/summary.html.leex:292
 msgid "try to sleep"
 msgstr "嘗試休眠"
 
@@ -321,11 +321,6 @@ msgstr "車外溫度"
 #: lib/teslamate_web/live/settings_live/index.html.leex:270
 msgid "Version"
 msgstr "車輛軟體版本"
-
-#, elixir-format
-#: lib/teslamate_web/live/car_live/summary.html.leex:74
-msgid "Software Update available"
-msgstr "有可用更新"
 
 #, elixir-format
 #: lib/teslamate_web/live/car_live/summary.html.leex:79
@@ -577,3 +572,8 @@ msgstr "後行李箱已打開"
 #: lib/teslamate_web/live/geofence_live/form.html.leex:66
 msgid "Per Minute"
 msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/teslamate_web/live/car_live/summary.html.leex:74
+msgid "Software Update available (%{version})"
+msgstr "有可用更新 (%{version})"

--- a/test/support/vehicle_case.ex
+++ b/test/support/vehicle_case.ex
@@ -124,14 +124,16 @@ defmodule TeslaMate.VehicleCase do
         )
       end
 
-      defp update_event(ts, state, version) do
+      defp update_event(ts, state, car_version, opts \\ []) do
         alias TeslaApi.Vehicle.State.VehicleState.SoftwareUpdate
+
+        update_version = Keyword.get(opts, :update_version)
 
         online_event(
           vehicle_state: %{
             timestamp: ts,
-            car_version: version,
-            software_update: %SoftwareUpdate{expected_duration_sec: 2700, status: state}
+            car_version: car_version,
+            software_update: %SoftwareUpdate{expected_duration_sec: 2700, status: state, version: update_version}
           },
           drive_state: %{timestamp: ts, latitude: 0.0, longitude: 0.0}
         )

--- a/test/support/vehicle_case.ex
+++ b/test/support/vehicle_case.ex
@@ -133,7 +133,11 @@ defmodule TeslaMate.VehicleCase do
           vehicle_state: %{
             timestamp: ts,
             car_version: car_version,
-            software_update: %SoftwareUpdate{expected_duration_sec: 2700, status: state, version: update_version}
+            software_update: %SoftwareUpdate{
+              expected_duration_sec: 2700,
+              status: state,
+              version: update_version
+            }
           },
           drive_state: %{timestamp: ts, latitude: 0.0, longitude: 0.0}
         )

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -49,6 +49,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       plugged_in: false,
       version: "2019.42",
       update_available: false,
+      update_version: "2019.43",
       is_preconditioning: true,
       is_user_present: false,
       is_climate_on: true,

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -8,7 +8,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, update_event(now_ts - 1, "available", nil)},
+      {:ok, update_event(now_ts - 1, "available", nil, update_version: "2019.8.5 3aaa23d")},
       {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3")},
       {:ok, update_event(now_ts + 1, "installing", "2019.8.4 530d1d3")},
       {:ok, update_event(now_ts + 2, "installing", "2019.8.4 530d1d3")},
@@ -31,7 +31,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert_receive {:pubsub,
                     {:broadcast, _server, _topic,
-                     %Summary{state: :online, since: s0, update_available: true}}}
+                     %Summary{state: :online, since: s0, update_available: true, update_version: "2019.8.5"}}}
 
     assert_receive {:start_update, ^car_id, [date: ^start_date]}
 
@@ -62,7 +62,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, update_event(now_ts - 1, "available", nil)},
+      {:ok, update_event(now_ts - 1, "available", nil, update_version: "2019.8.5 3aaa23d")},
       {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3")},
       {:ok, update_event(now_ts + 1, "foo", "2019.8.5 3aaa23d")},
       fn -> Process.sleep(10_000) end
@@ -79,7 +79,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert_receive {:pubsub,
                     {:broadcast, _server, _topic,
-                     %Summary{state: :online, since: s0, update_available: true}}}
+                     %Summary{state: :online, since: s0, update_available: true, update_version: "2019.8.5"}}}
 
     assert_receive {:start_update, ^car_id, date: ^start_date}
     assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :updating, since: s1}}}
@@ -102,8 +102,8 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3")},
-      {:ok, update_event(now_ts + 10, "available", "2019.8.4 530d1d3")},
+      {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaa23d")},
+      {:ok, update_event(now_ts + 10, "available", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaa23d")},
       fn -> Process.sleep(10_000) end
     ]
 
@@ -118,7 +118,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     assert_receive {:start_update, ^car_id, date: ^date}
 
     assert_receive {:pubsub,
-                    {:broadcast, _server, _topic, %Summary{state: :updating, version: "2019.8.4"}}}
+                    {:broadcast, _server, _topic, %Summary{state: :updating, version: "2019.8.4", update_version: "2019.8.5"}}}
 
     assert_receive {:cancel_update, _upate_id}, 200
 
@@ -127,7 +127,7 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     assert_receive {:insert_position, ^car_id, %{}}
 
     assert_receive {:pubsub,
-                    {:broadcast, _server, _topic, %Summary{state: :online, version: "2019.8.4"}}}
+                    {:broadcast, _server, _topic, %Summary{state: :online, version: "2019.8.4", update_version: "2019.8.5"}}}
 
     refute_receive _
   end

--- a/test/teslamate/vehicles/vehicle/updating_test.exs
+++ b/test/teslamate/vehicles/vehicle/updating_test.exs
@@ -31,7 +31,12 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert_receive {:pubsub,
                     {:broadcast, _server, _topic,
-                     %Summary{state: :online, since: s0, update_available: true, update_version: "2019.8.5"}}}
+                     %Summary{
+                       state: :online,
+                       since: s0,
+                       update_available: true,
+                       update_version: "2019.8.5"
+                     }}}
 
     assert_receive {:start_update, ^car_id, [date: ^start_date]}
 
@@ -79,7 +84,12 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     assert_receive {:pubsub,
                     {:broadcast, _server, _topic,
-                     %Summary{state: :online, since: s0, update_available: true, update_version: "2019.8.5"}}}
+                     %Summary{
+                       state: :online,
+                       since: s0,
+                       update_available: true,
+                       update_version: "2019.8.5"
+                     }}}
 
     assert_receive {:start_update, ^car_id, date: ^start_date}
     assert_receive {:pubsub, {:broadcast, _server, _topic, %Summary{state: :updating, since: s1}}}
@@ -102,8 +112,12 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, update_event(now_ts, "installing", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaa23d")},
-      {:ok, update_event(now_ts + 10, "available", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaa23d")},
+      {:ok,
+       update_event(now_ts, "installing", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaa23d")},
+      {:ok,
+       update_event(now_ts + 10, "available", "2019.8.4 530d1d3",
+         update_version: "2019.8.5 3aaa23d"
+       )},
       fn -> Process.sleep(10_000) end
     ]
 
@@ -118,7 +132,8 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     assert_receive {:start_update, ^car_id, date: ^date}
 
     assert_receive {:pubsub,
-                    {:broadcast, _server, _topic, %Summary{state: :updating, version: "2019.8.4", update_version: "2019.8.5"}}}
+                    {:broadcast, _server, _topic,
+                     %Summary{state: :updating, version: "2019.8.4", update_version: "2019.8.5"}}}
 
     assert_receive {:cancel_update, _upate_id}, 200
 
@@ -127,7 +142,8 @@ defmodule TeslaMate.Vehicles.Vehicle.UpdatingTest do
     assert_receive {:insert_position, ^car_id, %{}}
 
     assert_receive {:pubsub,
-                    {:broadcast, _server, _topic, %Summary{state: :online, version: "2019.8.4", update_version: "2019.8.5"}}}
+                    {:broadcast, _server, _topic,
+                     %Summary{state: :online, version: "2019.8.4", update_version: "2019.8.5"}}}
 
     refute_receive _
   end

--- a/test/teslamate_web/controllers/car_controller_test.exs
+++ b/test/teslamate_web/controllers/car_controller_test.exs
@@ -142,7 +142,7 @@ defmodule TeslaMateWeb.CarControllerTest do
            vehicle_state: %{
              timestamp: 0,
              car_version: "2019.40.50.7 ad132c7b057e",
-             software_update: %{status: "available"},
+             software_update: %{status: "available", version: "2020.4.1 4a4ad401858f"},
              locked: true,
              sentry_mode: true,
              fd_window: 1,
@@ -179,7 +179,7 @@ defmodule TeslaMateWeb.CarControllerTest do
       assert icon(html, "Sentry Mode", "shield-check")
       assert icon(html, "Windows open", "window-open")
       assert icon(html, "Doors open", "car-door")
-      assert icon(html, "Software Update available", "gift-outline")
+      assert icon(html, "Software Update available (2020.4.1)", "gift-outline")
       assert table_row(html, "Outside Temperature", "24 °C")
       assert table_row(html, "Inside Temperature", "23.2 °C")
       assert table_row(html, "Mileage", "42000 km")

--- a/test/teslamate_web/live/car_summary_live_test.exs
+++ b/test/teslamate_web/live/car_summary_live_test.exs
@@ -371,7 +371,8 @@ defmodule TeslaMateWeb.CarLive.SummaryTest do
     test "shows tag if update is available ", %{conn: conn} do
       events = [
         {:ok, online_event()},
-        {:ok, update_event(0, "available", nil)},
+        {:ok,
+         update_event(0, "available", "2019.8.4 530d1d3", update_version: "2019.8.5 3aaad23")},
         {:error, :unknown}
       ]
 
@@ -389,7 +390,10 @@ defmodule TeslaMateWeb.CarLive.SummaryTest do
                |> Floki.parse_document!()
                |> Floki.find(".icons .icon")
                |> Enum.find(
-                 &match?({"span", [_, {"data-tooltip", "Software Update available"}], _}, &1)
+                 &match?(
+                   {"span", [_, {"data-tooltip", "Software Update available (2019.8.5)"}], _},
+                   &1
+                 )
                )
     end
 

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -17,6 +17,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/healthy`                       | true                 | Health status of the logger for that vehicle                     |
 | `teslamate/cars/$car_id/version`                       | 2019.32.12.2         | Software Version                                                 |
 | `teslamate/cars/$car_id/update_available`              | false                | Indicates if a software update is available                      |
+| `teslamate/cars/$car_id/update_version`                | 2019.32.12.3         | Software version of the available update                         |
 |                                                        |                      |                                                                  |
 | `teslamate/cars/$car_id/model`                         | 3                    | Either "S", "3", "X" or "Y"                                      |
 | `teslamate/cars/$car_id/trim_badging`                  | P100D                | Trim badging                                                     |


### PR DESCRIPTION
When an update is available the version should be known and shown in the icon tooltip, which closes #943. 

Maybe we should not show the parantheses if the version is not available for some reason

If there is anything wrong with the formatting/localization/anything else, just let me know.