### PR TITLE
Always show 0% and 100% on state of charge diagram

### DIFF
--- a/grafana/dashboards/charge-level.json
+++ b/grafana/dashboards/charge-level.json
@@ -167,8 +167,8 @@
           "format": "percent",
           "label": "Charge Level",
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "100",
+          "min": "0",
           "show": true
         },
         {

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -447,7 +447,7 @@
           "label": null,
           "logBase": 1,
           "max": "100",
-          "min": null,
+          "min": "0",
           "show": true
         },
         {


### PR DESCRIPTION
In the beginning of recording data with teslamate it's likely that the SoC hasn't gone down close to 0. However the minimum value in the diagram is determined by the minimum SoC recorded in TeslaMate. The resulting diagram is arguably misleading.

This PR fixes that by fixing the minimum and maximum values for the SoC diagram to 0 and 100 respectively.

Caveat: I didn't test this change.