### PR TITLE
Gpx export

### DIFF
--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -27,6 +27,14 @@
       "url": "[[base_url:raw]]"
     },
     {
+      "icon": "",
+      "tags": [],
+      "title": "GpxExport",
+      "tooltip": "",
+      "type": "link",
+      "url": "[[base_url:raw]]/drive/$drive_id/gpx"
+    },
+    {
       "asDropdown": true,
       "icon": "external link",
       "tags": [
@@ -1268,5 +1276,5 @@
   "timezone": "",
   "title": "Drive Details",
   "uid": "zm7wN6Zgz",
-  "version": 1
+  "version": 4
 }

--- a/lib/teslamate_web/controllers/drive_controller.ex
+++ b/lib/teslamate_web/controllers/drive_controller.ex
@@ -1,0 +1,22 @@
+defmodule TeslaMateWeb.DriveController do
+  use TeslaMateWeb, :controller
+
+  require Logger
+
+  alias TeslaMate.Log.Drive
+  alias TeslaMate.Repo
+
+  def index(conn, %{"id" => id}) do
+    drive = Repo.get(Drive, id) |> Repo.preload(:positions)
+    filename = drive.start_date
+
+    conn
+    |> put_resp_content_type("application/xml")
+    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}.gpx"))
+    |> render("gpx.xml", drive: drive)
+  end
+end
+
+defmodule TeslaMateWeb.DriveView do
+  use TeslaMateWeb, :view
+end

--- a/lib/teslamate_web/controllers/drive_controller.ex
+++ b/lib/teslamate_web/controllers/drive_controller.ex
@@ -6,17 +6,21 @@ defmodule TeslaMateWeb.DriveController do
   alias TeslaMate.Log.Drive
   alias TeslaMate.Repo
 
-  def index(conn, %{"id" => id}) do
+  def gpx(conn, %{"id" => id}) do
     drive = Repo.get(Drive, id) |> Repo.preload(:positions)
-    filename = drive.start_date
+
+    case drive do
+      nil -> conn |> send_resp(404, "Drive not found")
+      drive -> send_gpx_file(conn, drive)
+    end
+  end
+
+  defp send_gpx_file(conn, drive) do
+    filename = "#{drive.start_date}.gpx"
 
     conn
     |> put_resp_content_type("application/xml")
-    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}.gpx"))
+    |> put_resp_header("content-disposition", ~s(attachment; filename="#{filename}"))
     |> render("gpx.xml", drive: drive)
   end
-end
-
-defmodule TeslaMateWeb.DriveView do
-  use TeslaMateWeb, :view
 end

--- a/lib/teslamate_web/controllers/drive_controller.ex
+++ b/lib/teslamate_web/controllers/drive_controller.ex
@@ -2,12 +2,15 @@ defmodule TeslaMateWeb.DriveController do
   use TeslaMateWeb, :controller
 
   require Logger
-
+  import Ecto.Query
   alias TeslaMate.Log.Drive
   alias TeslaMate.Repo
 
   def gpx(conn, %{"id" => id}) do
-    drive = Repo.get(Drive, id) |> Repo.preload(:positions)
+    drive =
+      Drive
+      |> Repo.get(id)
+      |> Repo.preload(positions: from(p in TeslaMate.Log.Position, order_by: p.date))
 
     case drive do
       nil -> conn |> send_resp(404, "Drive not found")

--- a/lib/teslamate_web/router.ex
+++ b/lib/teslamate_web/router.ex
@@ -31,7 +31,7 @@ defmodule TeslaMateWeb.Router do
     live "/geo-fences/:id/edit", GeoFenceLive.Form
     live "/charge-cost/:id", ChargeLive.Cost
     live "/import", ImportLive.Index
-    get "/drive/:id/gpx", DriveController, :index
+    get "/drive/:id/gpx", DriveController, :gpx
     get "/donate", DonateController, :index
   end
 

--- a/lib/teslamate_web/router.ex
+++ b/lib/teslamate_web/router.ex
@@ -31,6 +31,7 @@ defmodule TeslaMateWeb.Router do
     live "/geo-fences/:id/edit", GeoFenceLive.Form
     live "/charge-cost/:id", ChargeLive.Cost
     live "/import", ImportLive.Index
+    get "/drive/:id/gpx", DriveController, :index
     get "/donate", DonateController, :index
   end
 

--- a/lib/teslamate_web/templates/drive/gpx.xml.eex
+++ b/lib/teslamate_web/templates/drive/gpx.xml.eex
@@ -1,6 +1,6 @@
 <gpx version="1.1">
     <trk>
-        <name><%= @drive.start_date %></name>
+        <name><%= DateTime.to_iso8601(@drive.start_date) %></name>
         <trkseg>
             <%= for position <- @drive.positions do %>
             <trkpt lat="<%= position.latitude %>" lon="<%= position.longitude %>">

--- a/lib/teslamate_web/templates/drive/gpx.xml.eex
+++ b/lib/teslamate_web/templates/drive/gpx.xml.eex
@@ -1,0 +1,13 @@
+<gpx version="1.1">
+    <trk>
+        <name><%= @drive.start_date %></name>
+        <trkseg>
+            <%= for position <- @drive.positions do %>
+            <trkpt lat="<%= position.latitude %>" lon="<%= position.longitude %>">
+                <ele><%= position.elevation %></ele>
+                <time><%= DateTime.to_iso8601(position.date) %></time>
+            </trkpt>
+            <% end %>
+        </trkseg>
+    </trk>
+</gpx>

--- a/lib/teslamate_web/templates/layout/root.xml.eex
+++ b/lib/teslamate_web/templates/layout/root.xml.eex
@@ -1,0 +1,1 @@
+<%= @inner_content %>

--- a/lib/teslamate_web/views/drive_view.ex
+++ b/lib/teslamate_web/views/drive_view.ex
@@ -1,0 +1,3 @@
+defmodule TeslaMateWeb.DriveView do
+  use TeslaMateWeb, :view
+end

--- a/test/teslamate_web/controllers/drive_controller_test.exs
+++ b/test/teslamate_web/controllers/drive_controller_test.exs
@@ -1,0 +1,99 @@
+defmodule TeslaMateWeb.DriveControllerTest do
+  use TeslaMateWeb.ConnCase
+
+  alias TeslaMate.Log
+  alias TeslaMate.Repo
+
+  def car_fixture(attrs \\ %{}) do
+    {:ok, car} =
+      attrs
+      |> Enum.into(%{efficiency: 0.153, eid: 42, model: "M3", vid: 42, vin: "xxxxx"})
+      |> Log.create_car()
+
+    car
+  end
+
+  defp drive_fixture(car) do
+    {:ok, drive} = Log.start_drive(car)
+
+    Log.insert_position(drive, %{
+      date: DateTime.utc_now(),
+      latitude: 5.0,
+      longitude: 5.0,
+      elevation: 100
+    })
+
+    Log.insert_position(drive, %{
+      date: DateTime.utc_now(),
+      latitude: 10.0,
+      longitude: 10.0,
+      elevation: 200
+    })
+
+    drive |> Repo.preload(:positions)
+  end
+
+  describe "GET /drive/:id/gpx" do
+    test "sets xml and content-disposition headers", %{conn: conn} do
+      drive = drive_fixture(car_fixture())
+      assert conn = get(conn, Routes.drive_path(conn, :gpx, drive.id))
+
+      headers = Enum.into(conn.resp_headers, %{})
+      assert headers["content-disposition"] == ~s(attachment; filename="#{drive.start_date}.gpx")
+      assert response_content_type(conn, :xml) =~ "charset=utf-8"
+    end
+
+    test "renders gpx", %{conn: conn} do
+      drive = drive_fixture(car_fixture())
+      assert conn = get(conn, Routes.drive_path(conn, :gpx, drive.id))
+      xml = response(conn, 200)
+      assert xml =~ ~s(<gpx version="1.1")
+
+      document = Floki.parse_document!(xml)
+      xml_trackpoints = get_trackpoints(document)
+
+      drive_trackpoints = drive_trackpoints_to_trackpoints(drive)
+
+      assert xml_trackpoints == drive_trackpoints
+
+      track_name = document |> Floki.find("name") |> Floki.text()
+      assert track_name == DateTime.to_iso8601(drive.start_date)
+    end
+
+    test "returns 404 on drive not found", %{conn: conn} do
+      assert conn = get(conn, Routes.drive_path(conn, :gpx, "4"))
+      assert conn.status == 404
+    end
+
+    defp drive_trackpoints_to_trackpoints(drive) do
+      Enum.map(drive.positions, fn pos ->
+        %{
+          latitude: pos.latitude |> Decimal.to_string(),
+          longitude: pos.longitude |> Decimal.to_string(),
+          time: pos.date |> DateTime.to_iso8601(),
+          elevation: pos.elevation |> Integer.to_string()
+        }
+      end)
+    end
+
+    defp get_trackpoints(document) do
+      document
+      |> Floki.find("gpx trk trkseg trkpt")
+      |> Enum.map(&parse_trackpoint/1)
+    end
+
+    defp parse_trackpoint(trkpt) do
+      latitude = Floki.attribute(trkpt, "lat")
+      longitude = Floki.attribute(trkpt, "lon")
+      time = Floki.find(trkpt, "time") |> Floki.text()
+      elevation = Floki.find(trkpt, "ele") |> Floki.text()
+
+      %{
+        latitude: Enum.at(latitude, 0),
+        longitude: Enum.at(longitude, 0),
+        time: time,
+        elevation: elevation
+      }
+    end
+  end
+end

--- a/test/teslamate_web/controllers/drive_controller_test.exs
+++ b/test/teslamate_web/controllers/drive_controller_test.exs
@@ -30,6 +30,13 @@ defmodule TeslaMateWeb.DriveControllerTest do
       elevation: 200
     })
 
+    Log.insert_position(drive, %{
+      date: DateTime.utc_now() |> DateTime.add(-3600, :second),
+      latitude: 0.0,
+      longitude: 0.0,
+      elevation: 50
+    })
+
     drive |> Repo.preload(:positions)
   end
 
@@ -52,7 +59,7 @@ defmodule TeslaMateWeb.DriveControllerTest do
       document = Floki.parse_document!(xml)
       xml_trackpoints = get_trackpoints(document)
 
-      drive_trackpoints = drive_trackpoints_to_trackpoints(drive)
+      drive_trackpoints = drive_trackpoints_to_trackpoints(drive) |> Enum.sort_by(& &1.time)
 
       assert xml_trackpoints == drive_trackpoints
 


### PR DESCRIPTION
The current prototype exposes an endpoint to download a drive as a gpx file.
The drive details dashboard would have a link to the endpoint, so you could directly download the file from the dashboard.

As a note: I don't exactly know the details and features of GPX but as a minimal solution a list of trackpoints should be sufficient.

This is an effort to implement #722 

Todos:
- [x] Test the endpoint/view