### PR TITLE
fix version info on development guide & minor spelling fix

### DIFF
--- a/lib/teslamate/import.ex
+++ b/lib/teslamate/import.ex
@@ -118,7 +118,7 @@ defmodule TeslaMate.Import do
   def handle_event(:internal, :import, :running, %Data{files: files} = data) do
     Logger.info("Importing #{length(files)} file(s) ...")
 
-    case create_evennt_streams(data) do
+    case create_event_streams(data) do
       {:error, reason} ->
         {:next_state, {:error, reason}, {:next_event, :internal, :broadcast}}
 
@@ -209,7 +209,7 @@ defmodule TeslaMate.Import do
     end
   end
 
-  defp create_evennt_streams(%Data{files: files, timezone: tz}) do
+  defp create_event_streams(%Data{files: files, timezone: tz}) do
     alias TeslaApi.Vehicle.State.Drive
     alias TeslaApi.Vehicle, as: Veh
 

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -6,7 +6,7 @@ sidebar_label: Development and Contributing
 
 ## Requirements
 
-- **Elixir** >= 1.9
+- **Elixir** >= 1.11
 - **Postgres** >= 10
 - An **MQTT broker** e.g. mosquitto (_optional_)
 


### PR DESCRIPTION
I was trying to setup local dev and noticed that the recent updates to upgrade elixir 1.11.0 has resulted in this project not working with elixir<1.11 (such as use of `config_env/0`. I fixed that information here.

Additionally, I wanted to fix the debian guide too since erlang-solutions package site has not yet received 1.11.0 uploaded. I wasn't sure which one of various approaches you would want to take such as using version managers or downloading pre-compiled binaries from github release. Happy to create a PR to fix debian installation guide.