### PR TITLE
Replace default Graphana Web App logo with Teslamate logo

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -22,6 +22,7 @@ USER grafana
 
 COPY logo.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY favicon.png /usr/share/grafana/public/img/fav32.png
+COPY apple-touch-icon.png /usr/share/grafana/public/img/apple-touch-icon.png
 
 COPY datasource.yml /etc/grafana/provisioning/datasources/
 COPY dashboards.yml /etc/grafana/provisioning/dashboards/


### PR DESCRIPTION
Replace existing grafana logo with teslamate logo for apple devices when creating an "app" to home screen. Enhances existing #890 PR. Still have to check how this behaves with android devices, at least with the preliminary testing the results vary based on the used browser in android device.