### PR TITLE
Improve garage door automation example

### DIFF
--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -379,11 +379,11 @@ This automation triggers when the Tesla transitions from not_home to home. This 
   initial_state: on
   trigger:
     - platform: state
-      entity_id: switch.garage_door_switch
+      entity_id: device_tracker.tesla_location
       from: 'not_home'
       to: 'home'
   action:
-    - service: switch.turn_off
+    - service: switch.turn_on
       entity_id: switch.garage_door_switch
 ```
 


### PR DESCRIPTION
The current automation example incorrectly triggers based on the state of the garage door switch, rather than on the state of the Tesla's location. Also changed the action to turn on the garage door switch to be consistent with the description of the automation.