### PR TITLE
Fix unit of measurement for charge added shown in overview, documentation to be correct

### DIFF
--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -1101,7 +1101,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__time(date),\n  charger_power as \"Power [kW]\",\n  charger_actual_current as \"Current [A]\",\n  c.charge_energy_added as \"kW Added\"\nFROM\n  charges c\njoin\n  charging_processes p ON p.id = c.charging_process_id \nWHERE\n  $__timeFilter(date) and\n  p.car_id = $car_id\nORDER BY\n  date ASC",
+          "rawSql": "SELECT\n  $__time(date),\n  charger_power as \"Power [kW]\",\n  charger_actual_current as \"Current [A]\",\n  c.charge_energy_added as \"kWh Added\"\nFROM\n  charges c\njoin\n  charging_processes p ON p.id = c.charging_process_id \nWHERE\n  $__timeFilter(date) and\n  p.car_id = $car_id\nORDER BY\n  date ASC",
           "refId": "B",
           "select": [
             [

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -101,7 +101,7 @@ tesla_location:
 - platform: mqtt
   name: tesla_charge_energy_added
   state_topic: "teslamate/cars/1/charge_energy_added"
-  unit_of_measurement: "kW"
+  unit_of_measurement: "kWh"
   icon: mdi:battery-80
 
 - platform: mqtt

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -55,7 +55,7 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/battery_level`                 | 88                   | Battery Level Percentage                                         |
 | `teslamate/cars/$car_id/usable_battery_level`          | 85                   | Usable battery level percentage                                  |
 | `teslamate/cars/$car_id/plugged_in`                    | true                 | If car is currently plugged into a charger                       |
-| `teslamate/cars/$car_id/charge_energy_added`           | 5.06                 | Last added energy in kW                                          |
+| `teslamate/cars/$car_id/charge_energy_added`           | 5.06                 | Last added energy in kWh                                         |
 | `teslamate/cars/$car_id/charge_limit_soc`              | 90                   | Charge Limit Configured in Percentage                            |
 | `teslamate/cars/$car_id/charge_port_door_open`         | true                 | Indicates if the charger door is open                            |
 | `teslamate/cars/$car_id/charger_actual_current`        | 2.05                 | Current amperage supplied by charger                             |


### PR DESCRIPTION
The grafana overview dashboard and a few places in the documentation were using a wrong unit of measurement for charge energy added. They were incorrectly using a unit of power (kW) to describe a change in energy (kWh). This PR should fix the issue.