### PR TITLE
Average power and speed in the drive-details over 10 last data entries

### DIFF
--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1601722850623,
+  "iteration": 1607507903288,
   "links": [
     {
       "icon": "dashboard",
@@ -79,7 +79,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -108,7 +108,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__time(date),\n\tconvert_km(speed::numeric, '$length_unit') AS \"Speed [$length_unit/h]\",\n\tpower AS \"Power [kW]\",\n\tconvert_km([[preferred_range]]_battery_range_km, '$length_unit') AS \"Range ($preferred_range) [$length_unit]\",\n\tconvert_km(est_battery_range_km, '$length_unit') AS \"Range (est.) [$length_unit]\",\n\tbattery_level AS \"SOC [%]\",\n\tusable_battery_level AS \"usable SOC [%]\"\nFROM\n\tpositions\nWHERE\n car_id = $car_id AND\n $__timeFilter(date)\nORDER BY\n\tdate ASC",
+          "rawSql": "SELECT\n\t$__time(date),\n\tavg(convert_km(speed::numeric, '$length_unit')) OVER (ORDER BY date ROWS BETWEEN 10 PRECEDING AND CURRENT ROW) AS \"Speed [$length_unit/h]\",\n\tavg(power) OVER (ORDER BY date ROWS BETWEEN 10 PRECEDING AND CURRENT ROW) AS \"Power [kW]\",\n\tconvert_km([[preferred_range]]_battery_range_km, '$length_unit') AS \"Range ($preferred_range) [$length_unit]\",\n\tconvert_km(est_battery_range_km, '$length_unit') AS \"Range (est.) [$length_unit]\",\n\tbattery_level AS \"SOC [%]\",\n\tusable_battery_level AS \"usable SOC [%]\"\nFROM\n\tpositions\nWHERE\n car_id = $car_id AND\n $__timeFilter(date)\nORDER BY\n\tdate ASC",
           "refId": "A",
           "select": [
             [
@@ -256,7 +256,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "targets": [
         {
           "format": "table",
@@ -349,7 +349,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "targets": [
         {
           "format": "table",
@@ -440,7 +440,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "targets": [
         {
           "format": "table",
@@ -549,7 +549,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "targets": [
         {
           "format": "table",
@@ -724,7 +724,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -848,7 +848,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1015,7 +1015,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.2.1",
       "targets": [
         {
           "format": "table",


### PR DESCRIPTION
For your consideration.

This will smoothen the graph and take out the insignificant spikes. This looks much more like Tesla's own power graph, and provides me better insight and less "noise", personally. Curious to see what you think... I'm not sure if 10 is "smooth" enough for longer trips -- maybe there is a way to have a bigger moving average set for longer trips for example? But this is a start and you won't lose much detail averaging over 10 data points.

Before:

![Before](https://user-images.githubusercontent.com/183684/101622006-d14b5a00-3a16-11eb-9c64-a2b6c1a17a7d.png)

After:

![Screenshot 2020-12-09 at 12 05 01](https://user-images.githubusercontent.com/183684/101622060-e1633980-3a16-11eb-8ce4-44e60eb618b9.png)

And here's the new query:

![Screenshot 2020-12-09 at 12 02 45](https://user-images.githubusercontent.com/183684/101622092-e88a4780-3a16-11eb-8dac-972ffa331ea4.png)