### PR TITLE
Fix colors in Updates dashboard

### DIFF
--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -68,7 +68,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgb(255, 255, 255)",
+                "color": "#c7d0d9",
                 "value": null
               }
             ]
@@ -151,7 +151,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgb(255, 255, 255)",
+                "color": "#c7d0d9",
                 "value": null
               }
             ]


### PR DESCRIPTION
The panels in the Update dashboards are configured with a white font, which makes it invisible in the "light" theme of Grafana.

This PR changes the color to the same as used in e.g. the Overview dahboard:

OLD vs NEW schrrenshot: 
![image](https://user-images.githubusercontent.com/35613489/103479019-c7750680-4dca-11eb-9da7-139c102fd5c7.png)
