### PR TITLE
Fix typo in the link

### DIFF
--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -20,7 +20,7 @@
     {
       "icon": "dashboard",
       "tags": [],
-      "title": "TelsaMate",
+      "title": "TeslaMate",
       "type": "link",
       "url": "[[base_url:raw]]"
     },


### PR DESCRIPTION
I noticed this typo in the link to TeslaMate; so here is a fix!