### PR TITLE
Add link to Home Assistant addon

### DIFF
--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -28,4 +28,4 @@ LINK: [github.com/JakobLichterfeld/TeslaMate_Telegram_Bot](https://github.com/Ja
 
 ## [Home Assistant Addon](https://github.com/matt-FFFFFF/hassio-addon-teslamate)
 
-An unofficial Home Assistant addon for TeslaMate, with a PostgreSQL addon too. Works with the existing community `Grafana` and `Mosquitto` addons to provide a complete solution.
+An unofficial Home Assistant addon for TeslaMate, with a PostgreSQL addon too. Works with the existing community Grafana and Mosquitto addons to provide a complete solution.

--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -24,10 +24,10 @@ LINK: [github.com/MattJeanes/TeslaMateAgile](https://github.com/MattJeanes/Tesla
 
 This is a telegram bot written in Python to notify by Telegram message when a new SW update for your Tesla is available. It uses the MQTT topic which TeslaMate offers.
 
-LINK: [github.com/JakobLichterfeld/TeslaMate_Telegram_Bot](https://github.com/JakobLichterfeld/TeslaMate_Telegram_Bot))
+LINK: [github.com/JakobLichterfeld/TeslaMate_Telegram_Bot](https://github.com/JakobLichterfeld/TeslaMate_Telegram_Bot)
 
 ## [Home Assistant Addon](https://github.com/matt-FFFFFF/hassio-addon-teslamate)
 
 An unofficial Home Assistant addon for TeslaMate, with a PostgreSQL addon too. Works with the existing community Grafana and Mosquitto addons to provide a complete solution.
 
-LINK: [github.com/matt-FFFFFF/hassio-addon-teslamate](https://github.com/matt-FFFFFF/hassio-addon-teslamate))
+LINK: [github.com/matt-FFFFFF/hassio-addon-teslamate](https://github.com/matt-FFFFFF/hassio-addon-teslamate)

--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -25,3 +25,7 @@ LINK: [github.com/MattJeanes/TeslaMateAgile](https://github.com/MattJeanes/Tesla
 This is a telegram bot written in Python to notify by Telegram message when a new SW update for your Tesla is available. It uses the MQTT topic which TeslaMate offers.
 
 LINK: [github.com/JakobLichterfeld/TeslaMate_Telegram_Bot](https://github.com/JakobLichterfeld/TeslaMate_Telegram_Bot))
+
+## [Home Assistant Addon](https://github.com/matt-FFFFFF/hassio-addon-teslamate)
+
+An unofficial Home Assistant addon for TeslaMate, with a PostgreSQL addon too. Works with the existing community `Grafana` and `Mosquitto` addons to provide a complete solution.

--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -29,3 +29,5 @@ LINK: [github.com/JakobLichterfeld/TeslaMate_Telegram_Bot](https://github.com/Ja
 ## [Home Assistant Addon](https://github.com/matt-FFFFFF/hassio-addon-teslamate)
 
 An unofficial Home Assistant addon for TeslaMate, with a PostgreSQL addon too. Works with the existing community Grafana and Mosquitto addons to provide a complete solution.
+
+LINK: [github.com/matt-FFFFFF/hassio-addon-teslamate](https://github.com/matt-FFFFFF/hassio-addon-teslamate))


### PR DESCRIPTION
Would you be good enough to include a link to my HA addon? Now that it has Ingress support it's in a position to be shared more widely.