### PR TITLE
Set bucket size on charging heatmap. Fixes #1354

### DIFF
--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -518,7 +518,7 @@
       },
       "yBucketBound": "auto",
       "yBucketNumber": null,
-      "yBucketSize": null
+      "yBucketSize": 10.00001
     },
     {
       "aliasColors": {},


### PR DESCRIPTION
Sets bucket size to 10.00001 to make buckets more intuitive (subjective opinion).