### PR TITLE
Bump traefik to v2.4

### DIFF
--- a/website/docs/guides/traefik.md
+++ b/website/docs/guides/traefik.md
@@ -108,7 +108,7 @@ services:
       - mosquitto-data:/mosquitto/data
 
   proxy:
-    image: traefik:v2.3
+    image: traefik:v2.4
     restart: always
     command:
       - "--global.sendAnonymousUsage=false"


### PR DESCRIPTION
We could also rely on **_latest_** tag instead for traefik.. what you think @adriankumpf? :)