### PR TITLE
add drive state battery power to published mqtt topics

### DIFF
--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -12,7 +12,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     plugged_in scheduled_charging_start_time charge_limit_soc charger_power windows_open doors_open
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
-    model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation
+    model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -75,6 +75,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       # Drive State
       latitude: get_in_struct(vehicle, [:drive_state, :latitude]),
       longitude: get_in_struct(vehicle, [:drive_state, :longitude]),
+      power: get_in_struct(vehicle, [:drive_state, :power]),
       speed: speed(vehicle),
       shift_state: get_in_struct(vehicle, [:drive_state, :shift_state]),
       heading: get_in_struct(vehicle, [:drive_state, :heading]),

--- a/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
+++ b/test/teslamate/mqtt/pubsub/vehicle_subscriber_test.exs
@@ -40,6 +40,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriberTest do
       since: DateTime.utc_now(),
       latitude: 37.889602,
       longitude: 41.129182,
+      power: -9,
       speed: 40,
       heading: 340,
       outside_temp: 15,

--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -224,6 +224,12 @@ tesla_location:
    state_topic: "teslamate/cars/1/shift_state"
    icon: mdi:car-shift-pattern
 
+- platform: mqtt
+   name: tesla_power
+   state_topic: "teslamate/cars/1/power"
+   unit_of_measurement: W
+   icon: mdi:electricity
+
  - platform: mqtt
    name: tesla_speed
    state_topic: "teslamate/cars/1/speed"

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -9,61 +9,62 @@ The MQTT function within TeslaMate allows useful values to be published to an MQ
 
 Vehicle data will be published to the following topics:
 
-| Topic                                                  | Example              | Description                                                      |
-| ------------------------------------------------------ | -------------------- | ---------------------------------------------------------------- |
-| `teslamate/cars/$car_id/display_name`                  | Blue Thunder         | Vehicle Name                                                     |
-| `teslamate/cars/$car_id/state`                         | asleep               | Status of the vehicle (e.g. `online`, `asleep`, `charging`)      |
-| `teslamate/cars/$car_id/since`                         | 2019-02-29T23:00:07Z | Date of the last status change                                   |
-| `teslamate/cars/$car_id/healthy`                       | true                 | Health status of the logger for that vehicle                     |
-| `teslamate/cars/$car_id/version`                       | 2019.32.12.2         | Software Version                                                 |
-| `teslamate/cars/$car_id/update_available`              | false                | Indicates if a software update is available                      |
-| `teslamate/cars/$car_id/update_version`                | 2019.32.12.3         | Software version of the available update                         |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/model`                         | 3                    | Either "S", "3", "X" or "Y"                                      |
-| `teslamate/cars/$car_id/trim_badging`                  | P100D                | Trim badging                                                     |
-| `teslamate/cars/$car_id/exterior_color`                | DeepBlue             | The exterior color                                               |
-| `teslamate/cars/$car_id/wheel_type`                    | Pinwheel18           | The wheel type                                                   |
-| `teslamate/cars/$car_id/spoiler_type`                  | None                 | The spoiler type                                                 |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/geofence`                      | 🏡 Home              | The name of the Geo-fence, if one exists at the current position |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/latitude`                      | 35.278131            | Last reported car latitude                                       |
-| `teslamate/cars/$car_id/longitude`                     | 29.744801            | Last reported car longitude                                      |
-| `teslamate/cars/$car_id/shift_state`                   | D                    | Current/Last Shift State (D/N/R/P)                               |
-| `teslamate/cars/$car_id/speed`                         | 12                   | Current Speed in km/h                                            |
-| `teslamate/cars/$car_id/heading`                       | 340                  | Last reported car direction                                      |
-| `teslamate/cars/$car_id/elevation`                     | 70                   | Current elevation above sea level in meters                      |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/locked`                        | true                 | Indicates if the car is locked                                   |
-| `teslamate/cars/$car_id/sentry_mode`                   | false                | Indicates if Sentry Mode is active                               |
-| `teslamate/cars/$car_id/windows_open`                  | false                | Indicates if any of the windows are open                         |
-| `teslamate/cars/$car_id/doors_open`                    | false                | Indicates if any of the doors are open                           |
-| `teslamate/cars/$car_id/trunk_open`                    | false                | Indicates if the trunk is open                                   |
-| `teslamate/cars/$car_id/frunk_open`                    | false                | Indicates if the frunk is open                                   |
-| `teslamate/cars/$car_id/is_user_present`               | false                | Indicates if a user is present in the vehicle                    |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/is_climate_on`                 | true                 | Indicates if the climate control is on                           |
-| `teslamate/cars/$car_id/inside_temp`                   | 20.8                 | Inside Temperature in °C                                         |
-| `teslamate/cars/$car_id/outside_temp`                  | 18.4                 | Temperature in °C                                                |
-| `teslamate/cars/$car_id/is_preconditioning`            | false                | Indicates if the vehicle is being preconditioned                 |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/odometer`                      | 1653                 | Car odometer in km                                               |
-| `teslamate/cars/$car_id/est_battery_range_km`          | 372.5                | Estimated Range in km                                            |
-| `teslamate/cars/$car_id/rated_battery_range_km`        | 401.63               | Rated Range in km                                                |
-| `teslamate/cars/$car_id/ideal_battery_range_km`        | 335.79               | Ideal Range in km                                                |
-|                                                        |                      |                                                                  |
-| `teslamate/cars/$car_id/battery_level`                 | 88                   | Battery Level Percentage                                         |
-| `teslamate/cars/$car_id/usable_battery_level`          | 85                   | Usable battery level percentage                                  |
-| `teslamate/cars/$car_id/plugged_in`                    | true                 | If car is currently plugged into a charger                       |
-| `teslamate/cars/$car_id/charge_energy_added`           | 5.06                 | Last added energy in kWh                                         |
-| `teslamate/cars/$car_id/charge_limit_soc`              | 90                   | Charge Limit Configured in Percentage                            |
-| `teslamate/cars/$car_id/charge_port_door_open`         | true                 | Indicates if the charger door is open                            |
-| `teslamate/cars/$car_id/charger_actual_current`        | 2.05                 | Current amperage supplied by charger                             |
-| `teslamate/cars/$car_id/charger_phases`                | 3                    | Number of charger power phases (1-3)                             |
-| `teslamate/cars/$car_id/charger_power`                 | 48.9                 | Charger Power                                                    |
-| `teslamate/cars/$car_id/charger_voltage`               | 240                  | Charger Voltage                                                  |
-| `teslamate/cars/$car_id/scheduled_charging_start_time` | 2019-02-29T23:00:07Z | Start time of the scheduled charge                               |
-| `teslamate/cars/$car_id/time_to_full_charge`           | 1.83                 | Hours remaining to full charge                                   |
+|                         Topic                          |       Example        |                                      Description                                      |
+| ------------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------------- |
+| `teslamate/cars/$car_id/display_name`                  | Blue Thunder         | Vehicle Name                                                                          |
+| `teslamate/cars/$car_id/state`                         | asleep               | Status of the vehicle (e.g. `online`, `asleep`, `charging`)                           |
+| `teslamate/cars/$car_id/since`                         | 2019-02-29T23:00:07Z | Date of the last status change                                                        |
+| `teslamate/cars/$car_id/healthy`                       | true                 | Health status of the logger for that vehicle                                          |
+| `teslamate/cars/$car_id/version`                       | 2019.32.12.2         | Software Version                                                                      |
+| `teslamate/cars/$car_id/update_available`              | false                | Indicates if a software update is available                                           |
+| `teslamate/cars/$car_id/update_version`                | 2019.32.12.3         | Software version of the available update                                              |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/model`                         | 3                    | Either "S", "3", "X" or "Y"                                                           |
+| `teslamate/cars/$car_id/trim_badging`                  | P100D                | Trim badging                                                                          |
+| `teslamate/cars/$car_id/exterior_color`                | DeepBlue             | The exterior color                                                                    |
+| `teslamate/cars/$car_id/wheel_type`                    | Pinwheel18           | The wheel type                                                                        |
+| `teslamate/cars/$car_id/spoiler_type`                  | None                 | The spoiler type                                                                      |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/geofence`                      | 🏡 Home               | The name of the Geo-fence, if one exists at the current position                      |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/latitude`                      | 35.278131            | Last reported car latitude                                                            |
+| `teslamate/cars/$car_id/longitude`                     | 29.744801            | Last reported car longitude                                                           |
+| `teslamate/cars/$car_id/shift_state`                   | D                    | Current/Last Shift State (D/N/R/P)                                                    |
+| `teslamate/cars/$car_id/power`                         | -9                   | Current battery power in watts. Positive value on discharge, negative value on charge |
+| `teslamate/cars/$car_id/speed`                         | 12                   | Current Speed in km/h                                                                 |
+| `teslamate/cars/$car_id/heading`                       | 340                  | Last reported car direction                                                           |
+| `teslamate/cars/$car_id/elevation`                     | 70                   | Current elevation above sea level in meters                                           |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/locked`                        | true                 | Indicates if the car is locked                                                        |
+| `teslamate/cars/$car_id/sentry_mode`                   | false                | Indicates if Sentry Mode is active                                                    |
+| `teslamate/cars/$car_id/windows_open`                  | false                | Indicates if any of the windows are open                                              |
+| `teslamate/cars/$car_id/doors_open`                    | false                | Indicates if any of the doors are open                                                |
+| `teslamate/cars/$car_id/trunk_open`                    | false                | Indicates if the trunk is open                                                        |
+| `teslamate/cars/$car_id/frunk_open`                    | false                | Indicates if the frunk is open                                                        |
+| `teslamate/cars/$car_id/is_user_present`               | false                | Indicates if a user is present in the vehicle                                         |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/is_climate_on`                 | true                 | Indicates if the climate control is on                                                |
+| `teslamate/cars/$car_id/inside_temp`                   | 20.8                 | Inside Temperature in °C                                                              |
+| `teslamate/cars/$car_id/outside_temp`                  | 18.4                 | Temperature in °C                                                                     |
+| `teslamate/cars/$car_id/is_preconditioning`            | false                | Indicates if the vehicle is being preconditioned                                      |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/odometer`                      | 1653                 | Car odometer in km                                                                    |
+| `teslamate/cars/$car_id/est_battery_range_km`          | 372.5                | Estimated Range in km                                                                 |
+| `teslamate/cars/$car_id/rated_battery_range_km`        | 401.63               | Rated Range in km                                                                     |
+| `teslamate/cars/$car_id/ideal_battery_range_km`        | 335.79               | Ideal Range in km                                                                     |
+|                                                        |                      |                                                                                       |
+| `teslamate/cars/$car_id/battery_level`                 | 88                   | Battery Level Percentage                                                              |
+| `teslamate/cars/$car_id/usable_battery_level`          | 85                   | Usable battery level percentage                                                       |
+| `teslamate/cars/$car_id/plugged_in`                    | true                 | If car is currently plugged into a charger                                            |
+| `teslamate/cars/$car_id/charge_energy_added`           | 5.06                 | Last added energy in kWh                                                              |
+| `teslamate/cars/$car_id/charge_limit_soc`              | 90                   | Charge Limit Configured in Percentage                                                 |
+| `teslamate/cars/$car_id/charge_port_door_open`         | true                 | Indicates if the charger door is open                                                 |
+| `teslamate/cars/$car_id/charger_actual_current`        | 2.05                 | Current amperage supplied by charger                                                  |
+| `teslamate/cars/$car_id/charger_phases`                | 3                    | Number of charger power phases (1-3)                                                  |
+| `teslamate/cars/$car_id/charger_power`                 | 48.9                 | Charger Power                                                                         |
+| `teslamate/cars/$car_id/charger_voltage`               | 240                  | Charger Voltage                                                                       |
+| `teslamate/cars/$car_id/scheduled_charging_start_time` | 2019-02-29T23:00:07Z | Start time of the scheduled charge                                                    |
+| `teslamate/cars/$car_id/time_to_full_charge`           | 1.83                 | Hours remaining to full charge                                                        |
 
 :::note
 `$car_id` usually starts at 1


### PR DESCRIPTION
I added the current battery power output to the vehicle summary definition in order for it to be published via MQTT.
This data is needed in my use case to send data to the ABRP (https://abetterrouteplanner.com/) API since battery power is a mandatory field for the ABRP API.

I hope this is useful for others and would welcome if this could be merged