### PR TITLE
Update dashboards.sh

### DIFF
--- a/grafana/dashboards.sh
+++ b/grafana/dashboards.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The script assumes that basic authentication is configured
 # (change the login credentials with `LOGIN`).


### PR DESCRIPTION
make the script portable e.g. to BSD.

This small change allow to use the shell script also on BSDs where bash might be installed only as an option in /usr/local/bin