### PR TITLE
Standardise dashboard date formats

### DIFF
--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1583945409960,
+  "id": 24,
+  "iteration": 1616436965144,
   "links": [
     {
       "icon": "dashboard",
@@ -38,6 +39,7 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -60,6 +62,12 @@
     {
       "columns": [],
       "datasource": "TeslaMate",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 19,
@@ -69,7 +77,6 @@
       },
       "id": 6,
       "links": [],
-      "options": {},
       "pageSize": null,
       "scopedVars": {
         "car_id": {
@@ -93,7 +100,7 @@
           "linkTargetBlank": false,
           "linkTooltip": "View charge details",
           "linkUrl": "d/BHhxFeZRz?from=${__cell_0}&to=${__cell_1}&var-car_id=${__cell_3}&var-charging_process_id=${__cell_4}",
-          "pattern": "start_date_km",
+          "pattern": "start_date_iso",
           "type": "date"
         },
         {
@@ -112,7 +119,7 @@
           "linkTooltip": "View charge details",
           "linkUrl": "d/BHhxFeZRz?from=${__cell_0}&to=${__cell_1}&var-car_id=${__cell_3}&var-charging_process_id=${__cell_4}",
           "mappingType": 1,
-          "pattern": "start_date_mi",
+          "pattern": "start_date_us",
           "thresholds": [],
           "type": "date",
           "unit": "short"
@@ -514,7 +521,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "WITH data AS (\n    SELECT\n        (round(extract(epoch FROM start_date) - 10) * 1000) AS start_date_ts,\n        (round(extract(epoch FROM end_date) + 10) * 1000) AS end_date_ts,\n        start_date,\n        end_date,\n        CONCAT_WS(', ', COALESCE(addresses.name, nullif(CONCAT_WS(' ', addresses.road, addresses.house_number), '')), addresses.city) AS address,\n        g.name as geofence_name,\n        g.id as geofence_id,\n        p.latitude,\n        p.longitude,\n        cp.charge_energy_added,\n        cp.charge_energy_used,\n        duration_min,\n        start_battery_level,\n        end_battery_level,\n        start_[[preferred_range]]_range_km,\n        end_[[preferred_range]]_range_km,\n        outside_temp_avg,\n        cp.id,\n        lag(end_[[preferred_range]]_range_km) OVER (ORDER BY start_date) - start_[[preferred_range]]_range_km AS range_loss,\n        p.odometer - lag(p.odometer) OVER (ORDER BY start_date) AS distance,\n        cars.efficiency,\n        cp.car_id,\n        cost,\n        max(c.charger_voltage) as max_charger_voltage\n    FROM\n        charging_processes cp\n\t  LEFT JOIN charges c ON cp.id = c.charging_process_id\n    LEFT JOIN positions p ON p.id = cp.position_id\n    LEFT JOIN cars ON cars.id = cp.car_id\n    LEFT JOIN addresses ON addresses.id = cp.address_id\n    LEFT JOIN geofences g ON g.id = geofence_id\nWHERE \n    cp.car_id = $car_id AND\n    $__timeFilter(start_date) AND\n    (cp.charge_energy_added IS NULL OR cp.charge_energy_added > 0) AND\n    ('${geofence:pipe}' = '-1' OR geofence_id in ($geofence))\nGROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,21,p.odometer\nORDER BY\n    start_date\n)\nSELECT\n    start_date_ts,\n    end_date_ts,\n    CASE WHEN geofence_id IS NULL THEN CONCAT('new?lat=', latitude, '&lng=', longitude)\n         WHEN geofence_id IS NOT NULL THEN CONCAT(geofence_id, '/edit')\n    END as path,\n    car_id,\n    id,\n    -- Columns\n    start_date as start_date_[[length_unit]],\n    end_date,\n    COALESCE(geofence_name, address) as address,    \n    duration_min,\n    cost,\n    charge_energy_added,\n    charge_energy_used,\n    CASE WHEN charge_energy_used IS NULL THEN NULL ELSE LEAST(charge_energy_added / NULLIF(charge_energy_used, 0), 1.0) END as charging_efficiency,\n    convert_celsius(outside_temp_avg, '$temp_unit') AS outside_temp_avg_$temp_unit,\n    charge_energy_added * 60 / NULLIF (duration_min, 0) AS charge_energy_added_per_hour,\n    convert_km((end_[[preferred_range]]_range_km - start_[[preferred_range]]_range_km) * 60 / NULLIF (duration_min, 0), '$length_unit') AS range_added_per_hour_$length_unit,\n    start_battery_level,\n    end_battery_level,\n    convert_km(distance::numeric, '$length_unit') AS distance_$length_unit\n FROM\n    data\nWHERE\n    (distance >= 0 OR distance IS NULL)\n    AND max_charger_voltage >= '$voltage'\n    AND duration_min >= '$min_duration_min'\nORDER BY\n  start_date DESC;\n    ",
+          "rawSql": "WITH data AS (\n    SELECT\n        (round(extract(epoch FROM start_date) - 10) * 1000) AS start_date_ts,\n        (round(extract(epoch FROM end_date) + 10) * 1000) AS end_date_ts,\n        start_date,\n        end_date,\n        CONCAT_WS(', ', COALESCE(addresses.name, nullif(CONCAT_WS(' ', addresses.road, addresses.house_number), '')), addresses.city) AS address,\n        g.name as geofence_name,\n        g.id as geofence_id,\n        p.latitude,\n        p.longitude,\n        cp.charge_energy_added,\n        cp.charge_energy_used,\n        duration_min,\n        start_battery_level,\n        end_battery_level,\n        start_[[preferred_range]]_range_km,\n        end_[[preferred_range]]_range_km,\n        outside_temp_avg,\n        cp.id,\n        lag(end_[[preferred_range]]_range_km) OVER (ORDER BY start_date) - start_[[preferred_range]]_range_km AS range_loss,\n        p.odometer - lag(p.odometer) OVER (ORDER BY start_date) AS distance,\n        cars.efficiency,\n        cp.car_id,\n        cost,\n        max(c.charger_voltage) as max_charger_voltage\n    FROM\n        charging_processes cp\n\t  LEFT JOIN charges c ON cp.id = c.charging_process_id\n    LEFT JOIN positions p ON p.id = cp.position_id\n    LEFT JOIN cars ON cars.id = cp.car_id\n    LEFT JOIN addresses ON addresses.id = cp.address_id\n    LEFT JOIN geofences g ON g.id = geofence_id\nWHERE \n    cp.car_id = $car_id AND\n    $__timeFilter(start_date) AND\n    (cp.charge_energy_added IS NULL OR cp.charge_energy_added > 0) AND\n    ('${geofence:pipe}' = '-1' OR geofence_id in ($geofence))\nGROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,21,p.odometer\nORDER BY\n    start_date\n)\nSELECT\n    start_date_ts,\n    end_date_ts,\n    CASE WHEN geofence_id IS NULL THEN CONCAT('new?lat=', latitude, '&lng=', longitude)\n         WHEN geofence_id IS NOT NULL THEN CONCAT(geofence_id, '/edit')\n    END as path,\n    car_id,\n    id,\n    -- Columns\n    start_date as start_date_[[date_format]],\n    end_date,\n    COALESCE(geofence_name, address) as address,    \n    duration_min,\n    cost,\n    charge_energy_added,\n    charge_energy_used,\n    CASE WHEN charge_energy_used IS NULL THEN NULL ELSE LEAST(charge_energy_added / NULLIF(charge_energy_used, 0), 1.0) END as charging_efficiency,\n    convert_celsius(outside_temp_avg, '$temp_unit') AS outside_temp_avg_$temp_unit,\n    charge_energy_added * 60 / NULLIF (duration_min, 0) AS charge_energy_added_per_hour,\n    convert_km((end_[[preferred_range]]_range_km - start_[[preferred_range]]_range_km) * 60 / NULLIF (duration_min, 0), '$length_unit') AS range_added_per_hour_$length_unit,\n    start_battery_level,\n    end_battery_level,\n    convert_km(distance::numeric, '$length_unit') AS distance_$length_unit\n FROM\n    data\nWHERE\n    (distance >= 0 OR distance IS NULL)\n    AND max_charger_voltage >= '$voltage'\n    AND duration_min >= '$min_duration_min'\nORDER BY\n  start_date DESC;\n    ",
           "refId": "A",
           "select": [
             [
@@ -540,7 +547,7 @@
       "timeShift": null,
       "title": "Charges",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "cacheTimeout": null,
@@ -552,6 +559,12 @@
         "#d44a3a"
       ],
       "datasource": "TeslaMate",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "kwatth",
       "gauge": {
         "maxValue": 100,
@@ -583,7 +596,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "70%",
       "prefix": "Energy added:",
@@ -667,6 +679,12 @@
         "#d44a3a"
       ],
       "datasource": "TeslaMate",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "kwatth",
       "gauge": {
         "maxValue": 100,
@@ -698,7 +716,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "70%",
       "prefix": "Energy used:",
@@ -783,6 +800,12 @@
       ],
       "datasource": "TeslaMate",
       "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -814,7 +837,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "70%",
       "prefix": "Cost:",
@@ -889,11 +911,9 @@
       "valueName": "total"
     }
   ],
-  "schemaVersion": 22,
+  "schemaVersion": 26,
   "style": "dark",
-  "tags": [
-    "tesla"
-  ],
+  "tags": ["tesla"],
   "templating": {
     "list": [
       {
@@ -905,6 +925,7 @@
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "Car",
@@ -925,11 +946,13 @@
       {
         "allValue": null,
         "current": {
-          "text": "km",
-          "value": "km"
+          "selected": false,
+          "text": "mi",
+          "value": "mi"
         },
         "datasource": "TeslaMate",
         "definition": "select unit_of_length from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -950,11 +973,13 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "C",
           "value": "C"
         },
         "datasource": "TeslaMate",
         "definition": "select unit_of_temperature from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -975,11 +1000,13 @@
       {
         "allValue": null,
         "current": {
-          "text": "ideal",
-          "value": "ideal"
+          "selected": false,
+          "text": "rated",
+          "value": "rated"
         },
         "datasource": "TeslaMate",
         "definition": "select preferred_range from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -1000,11 +1027,13 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "http://localhost:4000",
           "value": "http://localhost:4000"
         },
         "datasource": "TeslaMate",
         "definition": "select base_url from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -1025,13 +1054,17 @@
       {
         "allValue": "-1",
         "current": {
-          "text": "All",
+          "selected": true,
+          "text": [
+            "All"
+          ],
           "value": [
             "$__all"
           ]
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM geofences ORDER BY name COLLATE \"C\" ASC;",
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Geofence",
@@ -1055,6 +1088,7 @@
           "text": "0",
           "value": "0"
         },
+        "error": null,
         "hide": 0,
         "label": "Enter min duration (minutes) here",
         "name": "min_duration_min",
@@ -1075,6 +1109,7 @@
           "text": "0",
           "value": "0"
         },
+        "error": null,
         "hide": 0,
         "label": "Enter min voltage here",
         "name": "voltage",
@@ -1088,6 +1123,33 @@
         "query": "0",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ISO",
+          "value": "ISO"
+        },
+        "datasource": "TeslaMate",
+        "definition": "select date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "select date_format from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:24",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -16,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1586855296897,
+  "id": 25,
+  "iteration": 1616437034420,
   "links": [
     {
       "icon": "dashboard",
@@ -61,6 +61,12 @@
     {
       "columns": [],
       "datasource": "TeslaMate",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 24,
@@ -86,7 +92,6 @@
       },
       "styles": [
         {
-          "$$hashKey": "object:391",
           "alias": "Date",
           "align": "auto",
           "colorMode": null,
@@ -102,13 +107,12 @@
           "linkTooltip": "View drive details",
           "linkUrl": "d/zm7wN6Zgz?from=${__cell_0}&to=${__cell_1}&var-car_id=${__cell_2}&var-drive_id=${__cell_6}",
           "mappingType": 1,
-          "pattern": "start_date_km",
+          "pattern": "start_date_iso",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
-          "$$hashKey": "object:392",
           "alias": "Consumption",
           "align": "auto",
           "colorMode": null,
@@ -126,7 +130,6 @@
           "unit": "Wh/km"
         },
         {
-          "$$hashKey": "object:3705",
           "alias": "Consumption",
           "align": "auto",
           "colorMode": null,
@@ -144,7 +147,6 @@
           "unit": "Wh/mi"
         },
         {
-          "$$hashKey": "object:393",
           "alias": "km",
           "align": "auto",
           "colorMode": null,
@@ -162,7 +164,6 @@
           "unit": "lengthkm"
         },
         {
-          "$$hashKey": "object:394",
           "alias": "kWh",
           "align": "auto",
           "colorMode": null,
@@ -180,7 +181,6 @@
           "unit": "kwatth"
         },
         {
-          "$$hashKey": "object:395",
           "alias": "Start",
           "align": "auto",
           "colorMode": null,
@@ -204,7 +204,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:396",
           "alias": "Destination",
           "align": "auto",
           "colorMode": null,
@@ -227,7 +226,6 @@
           "valueMaps": []
         },
         {
-          "$$hashKey": "object:397",
           "alias": "Temp",
           "align": "auto",
           "colorMode": null,
@@ -245,7 +243,6 @@
           "unit": "celsius"
         },
         {
-          "$$hashKey": "object:398",
           "alias": "Duration",
           "align": "auto",
           "colorMode": null,
@@ -266,7 +263,6 @@
           "unit": "m"
         },
         {
-          "$$hashKey": "object:399",
           "alias": "Efficiency",
           "align": "auto",
           "colorMode": "value",
@@ -287,7 +283,6 @@
           "unit": "percentunit"
         },
         {
-          "$$hashKey": "object:400",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -305,7 +300,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:401",
           "alias": "Speed",
           "align": "auto",
           "colorMode": null,
@@ -323,7 +317,6 @@
           "unit": "velocitykmh"
         },
         {
-          "$$hashKey": "object:402",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -341,7 +334,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:403",
           "alias": "mi",
           "align": "auto",
           "colorMode": null,
@@ -359,7 +351,6 @@
           "unit": "lengthmi"
         },
         {
-          "$$hashKey": "object:404",
           "alias": "Temp",
           "align": "auto",
           "colorMode": null,
@@ -377,7 +368,6 @@
           "unit": "fahrenheit"
         },
         {
-          "$$hashKey": "object:405",
           "alias": "Speed",
           "align": "auto",
           "colorMode": null,
@@ -395,7 +385,6 @@
           "unit": "velocitymph"
         },
         {
-          "$$hashKey": "object:406",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -413,7 +402,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:407",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -431,7 +419,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:408",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -449,7 +436,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:409",
           "alias": "Date",
           "align": "auto",
           "colorMode": null,
@@ -465,13 +451,12 @@
           "linkTooltip": "View drive details",
           "linkUrl": "d/zm7wN6Zgz?from=${__cell_0}&to=${__cell_1}&var-car_id=${__cell_2}&var-drive_id=${__cell_6}",
           "mappingType": 1,
-          "pattern": "start_date_mi",
+          "pattern": "start_date_us",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
-          "$$hashKey": "object:410",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -489,7 +474,6 @@
           "unit": "percent"
         },
         {
-          "$$hashKey": "object:411",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -507,7 +491,6 @@
           "unit": "percent"
         },
         {
-          "$$hashKey": "object:412",
           "alias": "❄",
           "align": "auto",
           "colorMode": "value",
@@ -525,19 +508,16 @@
           "unit": "short",
           "valueMaps": [
             {
-              "$$hashKey": "object:671",
               "text": "❄",
               "value": "1"
             },
             {
-              "$$hashKey": "object:672",
               "text": "",
               "value": "0"
             }
           ]
         },
         {
-          "$$hashKey": "object:413",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -555,7 +535,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:683",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -573,7 +552,6 @@
           "unit": "short"
         },
         {
-          "$$hashKey": "object:414",
           "alias": "max Power",
           "align": "auto",
           "colorMode": null,
@@ -596,7 +574,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "WITH data AS (\n  SELECT\n    round(extract(epoch FROM start_date)) * 1000 AS start_date_ts,\n    round(extract(epoch FROM end_date)) * 1000 AS end_date_ts,\n    car.id as car_id,\n    CASE WHEN start_geofence.id IS NULL THEN CONCAT('new?lat=', start_position.latitude, '&lng=', start_position.longitude)\n         WHEN start_geofence.id IS NOT NULL THEN CONCAT(start_geofence.id, '/edit')\n    END as start_path,\n    CASE WHEN end_geofence.id IS NULL THEN CONCAT('new?lat=', end_position.latitude, '&lng=', end_position.longitude)\n         WHEN end_geofence.id IS NOT NULL THEN CONCAT(end_geofence.id, '/edit')\n    END as end_path,\n    TO_CHAR((duration_min * INTERVAL '1 minute'), 'HH24:MI') as duration_str,\n    drives.id as drive_id,\n    -- Columns\n    start_date,\n    COALESCE(start_geofence.name, CONCAT_WS(', ', COALESCE(start_address.name, nullif(CONCAT_WS(' ', start_address.road, start_address.house_number), '')), start_address.city)) AS start_address,\n    COALESCE(end_geofence.name, CONCAT_WS(', ', COALESCE(end_address.name, nullif(CONCAT_WS(' ', end_address.road, end_address.house_number), '')), end_address.city)) AS end_address,\n    duration_min,\n    distance,\n    start_position.usable_battery_level as start_usable_battery_level,\n    start_position.battery_level as start_battery_level,\n    end_position.usable_battery_level as end_usable_battery_level,\n    end_position.battery_level as end_battery_level,\n   case when (start_position.battery_level != start_position.usable_battery_level OR end_position.battery_level != end_position.usable_battery_level) = true then true else false end  as reduced_range,\n    duration_min > 1 AND distance > 1 AND ( \n      start_position.usable_battery_level IS NULL OR end_position.usable_battery_level IS NULL\tOR\n      (end_position.battery_level - end_position.usable_battery_level) = 0 \n    ) as is_sufficiently_precise,\n    NULLIF(GREATEST(start_[[preferred_range]]_range_km - end_[[preferred_range]]_range_km, 0), 0) as range_diff,\n    car.efficiency as car_efficiency,\n    outside_temp_avg,\n    distance / NULLIF(duration_min, 0) * 60 AS avg_speed,\n    power_max\n  FROM drives\n  LEFT JOIN addresses start_address ON start_address_id = start_address.id\n  LEFT JOIN addresses end_address ON end_address_id = end_address.id\n  LEFT JOIN positions start_position ON start_position_id = start_position.id\n  LEFT JOIN positions end_position ON end_position_id = end_position.id\n  LEFT JOIN geofences start_geofence ON start_geofence_id = start_geofence.id\n  LEFT JOIN geofences end_geofence ON end_geofence_id = end_geofence.id\n  LEFT JOIN cars car ON car.id = drives.car_id\n  WHERE $__timeFilter(start_date) AND drives.car_id = $car_id AND convert_km(distance::numeric, '$length_unit') >= $min_dist AND convert_km(distance::numeric, '$length_unit') / NULLIF(duration_min, 0) * 60 >= $min_speed\n  ORDER BY start_date DESC\n)\nSELECT\n    start_date_ts,\n    end_date_ts,\n    car_id,\n    start_path,\n    end_path,\n    duration_str,\n    drive_id,\n    -- Columns\n    start_date as start_date_[[length_unit]],\n    start_address,\n    end_address,\n    duration_min,\n    convert_km(distance::numeric, '$length_unit') AS distance_$length_unit,\n    start_battery_level as \"% Start\",\n    end_battery_level as \"% End\",\n    convert_celsius(outside_temp_avg, '$temp_unit') AS outside_temp_$temp_unit,\n    convert_km(avg_speed::numeric, '$length_unit') AS speed_avg_$length_unit,\n    power_max,\n    reduced_range as has_reduced_range,\n    range_diff * car_efficiency as \"consumption_kWh\",\n    CASE WHEN is_sufficiently_precise THEN range_diff * car_efficiency / distance * 1000 * CASE WHEN '$length_unit' = 'km' THEN 1\n                                                                                                WHEN '$length_unit' = 'mi' THEN 1.60934\n                                                                                           END\n    END AS consumption_kWh_$length_unit,\n    CASE WHEN is_sufficiently_precise THEN distance / range_diff\n         ELSE NULL\n    END AS efficiency\nFROM data;",
+          "rawSql": "WITH data AS (\n  SELECT\n    round(extract(epoch FROM start_date)) * 1000 AS start_date_ts,\n    round(extract(epoch FROM end_date)) * 1000 AS end_date_ts,\n    car.id as car_id,\n    CASE WHEN start_geofence.id IS NULL THEN CONCAT('new?lat=', start_position.latitude, '&lng=', start_position.longitude)\n         WHEN start_geofence.id IS NOT NULL THEN CONCAT(start_geofence.id, '/edit')\n    END as start_path,\n    CASE WHEN end_geofence.id IS NULL THEN CONCAT('new?lat=', end_position.latitude, '&lng=', end_position.longitude)\n         WHEN end_geofence.id IS NOT NULL THEN CONCAT(end_geofence.id, '/edit')\n    END as end_path,\n    TO_CHAR((duration_min * INTERVAL '1 minute'), 'HH24:MI') as duration_str,\n    drives.id as drive_id,\n    -- Columns\n    start_date,\n    COALESCE(start_geofence.name, CONCAT_WS(', ', COALESCE(start_address.name, nullif(CONCAT_WS(' ', start_address.road, start_address.house_number), '')), start_address.city)) AS start_address,\n    COALESCE(end_geofence.name, CONCAT_WS(', ', COALESCE(end_address.name, nullif(CONCAT_WS(' ', end_address.road, end_address.house_number), '')), end_address.city)) AS end_address,\n    duration_min,\n    distance,\n    start_position.usable_battery_level as start_usable_battery_level,\n    start_position.battery_level as start_battery_level,\n    end_position.usable_battery_level as end_usable_battery_level,\n    end_position.battery_level as end_battery_level,\n   case when (start_position.battery_level != start_position.usable_battery_level OR end_position.battery_level != end_position.usable_battery_level) = true then true else false end  as reduced_range,\n    duration_min > 1 AND distance > 1 AND ( \n      start_position.usable_battery_level IS NULL OR end_position.usable_battery_level IS NULL\tOR\n      (end_position.battery_level - end_position.usable_battery_level) = 0 \n    ) as is_sufficiently_precise,\n    NULLIF(GREATEST(start_[[preferred_range]]_range_km - end_[[preferred_range]]_range_km, 0), 0) as range_diff,\n    car.efficiency as car_efficiency,\n    outside_temp_avg,\n    distance / NULLIF(duration_min, 0) * 60 AS avg_speed,\n    power_max\n  FROM drives\n  LEFT JOIN addresses start_address ON start_address_id = start_address.id\n  LEFT JOIN addresses end_address ON end_address_id = end_address.id\n  LEFT JOIN positions start_position ON start_position_id = start_position.id\n  LEFT JOIN positions end_position ON end_position_id = end_position.id\n  LEFT JOIN geofences start_geofence ON start_geofence_id = start_geofence.id\n  LEFT JOIN geofences end_geofence ON end_geofence_id = end_geofence.id\n  LEFT JOIN cars car ON car.id = drives.car_id\n  WHERE $__timeFilter(start_date) AND drives.car_id = $car_id AND convert_km(distance::numeric, '$length_unit') >= $min_dist AND convert_km(distance::numeric, '$length_unit') / NULLIF(duration_min, 0) * 60 >= $min_speed\n  ORDER BY start_date DESC\n)\nSELECT\n    start_date_ts,\n    end_date_ts,\n    car_id,\n    start_path,\n    end_path,\n    duration_str,\n    drive_id,\n    -- Columns\n    start_date as start_date_[[date_format]],\n    start_address,\n    end_address,\n    duration_min,\n    convert_km(distance::numeric, '$length_unit') AS distance_$length_unit,\n    start_battery_level as \"% Start\",\n    end_battery_level as \"% End\",\n    convert_celsius(outside_temp_avg, '$temp_unit') AS outside_temp_$temp_unit,\n    convert_km(avg_speed::numeric, '$length_unit') AS speed_avg_$length_unit,\n    power_max,\n    reduced_range as has_reduced_range,\n    range_diff * car_efficiency as \"consumption_kWh\",\n    CASE WHEN is_sufficiently_precise THEN range_diff * car_efficiency / distance * 1000 * CASE WHEN '$length_unit' = 'km' THEN 1\n                                                                                                WHEN '$length_unit' = 'mi' THEN 1.60934\n                                                                                           END\n    END AS consumption_kWh_$length_unit,\n    CASE WHEN is_sufficiently_precise THEN distance / range_diff\n         ELSE NULL\n    END AS efficiency\nFROM data;",
           "refId": "A",
           "select": [
             [
@@ -620,14 +598,12 @@
       ],
       "title": "Drive",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
-  "schemaVersion": 22,
+  "schemaVersion": 26,
   "style": "dark",
-  "tags": [
-    "tesla"
-  ],
+  "tags": ["tesla"],
   "templating": {
     "list": [
       {
@@ -639,9 +615,9 @@
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
+        "error": null,
         "hide": 2,
         "includeAll": true,
-        "index": -1,
         "label": "Car",
         "multi": false,
         "name": "car_id",
@@ -660,14 +636,15 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "C",
           "value": "C"
         },
         "datasource": "TeslaMate",
         "definition": "select unit_of_temperature from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
-        "index": -1,
         "label": "temperature unit",
         "multi": false,
         "name": "temp_unit",
@@ -686,14 +663,15 @@
       {
         "allValue": null,
         "current": {
-          "text": "km",
-          "value": "km"
+          "selected": false,
+          "text": "mi",
+          "value": "mi"
         },
         "datasource": "TeslaMate",
         "definition": "select unit_of_length from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
-        "index": -1,
         "label": "length unit",
         "multi": false,
         "name": "length_unit",
@@ -712,14 +690,15 @@
       {
         "allValue": null,
         "current": {
-          "text": "ideal",
-          "value": "ideal"
+          "selected": false,
+          "text": "rated",
+          "value": "rated"
         },
         "datasource": "TeslaMate",
         "definition": "select preferred_range from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
-        "index": -1,
         "label": "",
         "multi": false,
         "name": "preferred_range",
@@ -738,14 +717,15 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "http://localhost:4000",
           "value": "http://localhost:4000"
         },
         "datasource": "TeslaMate",
         "definition": "select base_url from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
-        "index": -1,
         "label": "",
         "multi": false,
         "name": "base_url",
@@ -763,13 +743,14 @@
       },
       {
         "allValue": null,
-        "includeAll": false,
         "current": {
           "selected": false,
           "text": "0",
           "value": "0"
         },
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": "Enter min distance here",
         "name": "min_dist",
         "options": [],
@@ -779,19 +760,47 @@
       },
       {
         "allValue": null,
-        "includeAll": false,
         "current": {
           "selected": false,
           "text": "0",
           "value": "0"
         },
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": "Enter min speed here",
         "name": "min_speed",
         "options": [],
         "query": "0",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ISO",
+          "value": "ISO"
+        },
+        "datasource": "TeslaMate",
+        "definition": "select date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "length unit",
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "select date_format from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -827,8 +836,5 @@
   "timezone": "",
   "title": "Drives",
   "uid": "Y8upc6ZRk",
-  "variables": {
-    "list": []
-  },
   "version": 1
 }

--- a/grafana/dashboards/locations.json
+++ b/grafana/dashboards/locations.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1594301176676,
+  "id": 9,
+  "iteration": 1617727063189,
   "links": [
     {
       "icon": "dashboard",
@@ -86,7 +87,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -172,7 +173,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -258,7 +259,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -344,7 +345,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -427,7 +428,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -508,7 +509,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
@@ -577,19 +578,44 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Date"
+              "options": "date_us"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "dateTimeAsLocal"
+                "value": "dateTimeAsUS"
               },
               {
                 "id": "custom.width",
-                "value": 160
+                "value": 170
+              },
+              {
+                "id": "displayName",
+                "value": "Date"
               }
             ]
           },
+           {
+            "matcher": {
+              "id": "byName",
+              "options": "date_iso"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.width",
+                "value": 159
+              },
+              {
+                "id": "displayName",
+                "value": "Date"
+              }
+            ]
+          },         
+          
           {
             "matcher": {
               "id": "byName",
@@ -600,6 +626,12 @@
                 "id": "custom.width"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName"
+            },
+            "properties": []
           }
         ]
       },
@@ -614,14 +646,14 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "format": "table",
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  max(end_date) as \"Date\",\n  count(*) as visited,\n  COALESCE(g.name, array_to_string(((string_to_array(a.display_name, ', ', ''))[0:2]), ', ')) AS \"Address\",\n\tCOALESCE(city, neighbourhood) as \"City\"\nFROM drives t\nINNER JOIN addresses a ON end_address_id = a.id\nLEFT JOIN geofences g ON end_geofence_id = g.id\nWHERE a.display_name ilike '%$address_filter%' or g.name ilike '%$address_filter%'\nGROUP BY 3,4\nORDER BY visited DESC\nLIMIT 100",
+          "rawSql": "SELECT\n  max(end_date) as date_[[date_format]],\n  count(*) as visited,\n  COALESCE(g.name, array_to_string(((string_to_array(a.display_name, ', ', ''))[0:2]), ', ')) AS \"Address\",\n\tCOALESCE(city, neighbourhood) as \"City\"\nFROM drives t\nINNER JOIN addresses a ON end_address_id = a.id\nLEFT JOIN geofences g ON end_geofence_id = g.id\nWHERE a.display_name ilike '%$address_filter%' or g.name ilike '%$address_filter%'\nGROUP BY 3,4\nORDER BY visited DESC\nLIMIT 100",
           "refId": "A",
           "select": [
             [
@@ -994,6 +1026,7 @@
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "Car",
@@ -1020,6 +1053,7 @@
         },
         "datasource": "TeslaMate",
         "definition": "select base_url from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -1043,6 +1077,7 @@
           "text": "",
           "value": ""
         },
+        "error": null,
         "hide": 0,
         "label": "Address",
         "name": "address_filter",
@@ -1056,6 +1091,33 @@
         "query": "",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "us",
+          "value": "us"
+        },
+        "datasource": "TeslaMate",
+        "definition": "SELECT date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "SELECT date_format from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },

--- a/grafana/dashboards/statistics.json
+++ b/grafana/dashboards/statistics.json
@@ -491,7 +491,7 @@
           }
         ]
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "7.3.7",
       "repeat": null,
       "repeatDirection": "h",
       "scopedVars": {
@@ -881,7 +881,7 @@
         "multi": false,
         "name": "timezone",
         "options": [],
-        "query": "select current_setting('TIMEZONE'), name from pg_timezone_names where abbrev ~ '^[a-zA-Z]{3,4}$' and name not like 'posix%' order by 2;",
+		"query": "select current_setting('TIMEZONE'), name from pg_timezone_names where abbrev ~ '^[a-zA-Z]{3,4}$' and name not like 'posix%' order by 2;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -908,6 +908,33 @@
         "name": "base_url",
         "options": [],
         "query": "select base_url from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "American",
+          "value": "American"
+        },
+        "datasource": "TeslaMate",
+        "definition": "select date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "length unit",
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "select date_format from settings limit 1;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -250,7 +250,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "time"
+              "options": "date_us"
             },
             "properties": [
               {
@@ -263,7 +263,7 @@
               },
               {
                 "id": "unit",
-                "value": "dateTimeAsIso"
+                "value": "dateTimeAsUS"
               }
             ]
           },
@@ -353,6 +353,35 @@
               }
             ]
           },
+ 
+ 
+ 
+ 
+ 
+           {
+            "matcher": {
+              "id": "byName",
+              "options": "date_iso"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Date"
+              },
+			  {
+                "id": "custom.width",
+                "value": 200
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              }
+            ]
+          },             
           {
             "matcher": {
               "id": "byName",
@@ -526,7 +555,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "with u as (\r\n  select *, coalesce(lag(start_date) over(order by start_date desc), now()) as next_start_date \r\n  from updates\r\n  where car_id = $car_id and $__timeFilter(start_date)\r\n),\r\nrng as (\r\n  SELECT\r\n\t  to_timestamp(floor(extract(epoch from date)/21600)*21600) AS date,\r\n\t  (sum([[preferred_range]]_battery_range_km) / sum(coalesce(usable_battery_level,battery_level)) * 100 ) AS \"battery_rng\"\r\n  FROM (\r\n    select battery_level, usable_battery_level, date, rated_battery_range_km, ideal_battery_range_km\r\n    from positions\r\n    where car_id = $car_id and $__timeFilter(date) and ideal_battery_range_km is not null\r\n    union all\r\n    select battery_level, coalesce(usable_battery_level,battery_level) as usable_battery_level, date, rated_battery_range_km, ideal_battery_range_km\r\n    from charges c\r\n    join charging_processes p ON p.id = c.charging_process_id \r\n    where $__timeFilter(date) and p.car_id = $car_id\r\n  ) as data\r\n  GROUP BY 1\r\n)\r\n\r\nselect\t\r\n  u.start_date as time,\r\n\textract(EPOCH FROM u.end_date - u.start_date) AS update_duration,\r\n\textract(EPOCH FROM u.start_date - lag(u.start_date) OVER (ORDER BY u.start_date)) AS since_last_update,\r\n\tsplit_part(u.version, ' ', 1) as version,\r\n\tcount(distinct cp.id) as chg_ct,\r\n\tconvert_km(avg(r.battery_rng), '$length_unit')::numeric(6,2) AS \"Avg [[preferred_range]] range [$length_unit]\"\r\nfrom u u\r\nleft join charging_processes cp\r\n\tON u.car_id = cp.car_id\r\n \tand cp.start_date between u.start_date and u.next_start_date\r\nleft join rng r\r\n\tON r.date between u.start_date and u.next_start_date\r\ngroup by u.car_id,\r\n\tu.start_date,\r\n\tu.end_date,\r\n\tnext_start_date,\r\n\tsplit_part(u.version, ' ', 1)",
+          "rawSql": "with u as (\r\n  select *, coalesce(lag(start_date) over(order by start_date desc), now()) as next_start_date \r\n  from updates\r\n  where car_id = $car_id and $__timeFilter(start_date)\r\n),\r\nrng as (\r\n  SELECT\r\n\t  to_timestamp(floor(extract(epoch from date)/21600)*21600) AS date,\r\n\t  (sum([[preferred_range]]_battery_range_km) / sum(coalesce(usable_battery_level,battery_level)) * 100 ) AS \"battery_rng\"\r\n  FROM (\r\n    select battery_level, usable_battery_level, date, rated_battery_range_km, ideal_battery_range_km\r\n    from positions\r\n    where car_id = $car_id and $__timeFilter(date) and ideal_battery_range_km is not null\r\n    union all\r\n    select battery_level, coalesce(usable_battery_level,battery_level) as usable_battery_level, date, rated_battery_range_km, ideal_battery_range_km\r\n    from charges c\r\n    join charging_processes p ON p.id = c.charging_process_id \r\n    where $__timeFilter(date) and p.car_id = $car_id\r\n  ) as data\r\n  GROUP BY 1\r\n)\r\n\r\nselect\t\r\n  u.start_date as date_[[date_format]],\r\n\textract(EPOCH FROM u.end_date - u.start_date) AS update_duration,\r\n\textract(EPOCH FROM u.start_date - lag(u.start_date) OVER (ORDER BY u.start_date)) AS since_last_update,\r\n\tsplit_part(u.version, ' ', 1) as version,\r\n\tcount(distinct cp.id) as chg_ct,\r\n\tconvert_km(avg(r.battery_rng), '$length_unit')::numeric(6,2) AS \"Avg [[preferred_range]] range [$length_unit]\"\r\nfrom u u\r\nleft join charging_processes cp\r\n\tON u.car_id = cp.car_id\r\n \tand cp.start_date between u.start_date and u.next_start_date\r\nleft join rng r\r\n\tON r.date between u.start_date and u.next_start_date\r\ngroup by u.car_id,\r\n\tu.start_date,\r\n\tu.end_date,\r\n\tnext_start_date,\r\n\tsplit_part(u.version, ' ', 1)",
           "refId": "A",
           "select": [
             [
@@ -666,6 +695,33 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "us",
+          "value": "us"
+        },
+        "datasource": "TeslaMate",
+        "definition": "select date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "select date_format from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false     
       }
     ]
   },

--- a/grafana/dashboards/vampire-drain.json
+++ b/grafana/dashboards/vampire-drain.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1598013901953,
+  "iteration": 1617663619325,
   "links": [
     {
       "icon": "dashboard",
@@ -92,6 +92,7 @@
       },
       "styles": [
         {
+          "$$hashKey": "object:142",
           "alias": "Start",
           "align": "auto",
           "colorMode": null,
@@ -107,12 +108,13 @@
           "linkTooltip": "",
           "linkUrl": "d/zm7wN6Zgz?from=${__cell_0}&to=${__cell_1}",
           "mappingType": 1,
-          "pattern": "start_date_km",
+          "pattern": "start_date_iso",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
+          "$$hashKey": "object:143",
           "alias": "End",
           "align": "auto",
           "colorMode": null,
@@ -124,12 +126,13 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "end_date_km",
+          "pattern": "end_date_iso",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
+          "$$hashKey": "object:144",
           "alias": "TR Loss",
           "align": "auto",
           "colorMode": null,
@@ -147,6 +150,7 @@
           "unit": "lengthkm"
         },
         {
+          "$$hashKey": "object:145",
           "alias": "Period",
           "align": "auto",
           "colorMode": "value",
@@ -166,6 +170,7 @@
           "unit": "s"
         },
         {
+          "$$hashKey": "object:146",
           "alias": "TR Loss / h",
           "align": "auto",
           "colorMode": null,
@@ -183,6 +188,7 @@
           "unit": "lengthkm"
         },
         {
+          "$$hashKey": "object:147",
           "alias": "",
           "align": "auto",
           "colorMode": null,
@@ -200,6 +206,7 @@
           "unit": "short"
         },
         {
+          "$$hashKey": "object:148",
           "alias": "Standby",
           "align": "auto",
           "colorMode": "value",
@@ -220,6 +227,7 @@
           "unit": "percentunit"
         },
         {
+          "$$hashKey": "object:149",
           "alias": "kWh",
           "align": "auto",
           "colorMode": null,
@@ -237,6 +245,7 @@
           "unit": "kwatth"
         },
         {
+          "$$hashKey": "object:150",
           "alias": "Ø-Power",
           "align": "auto",
           "colorMode": null,
@@ -254,6 +263,7 @@
           "unit": "watt"
         },
         {
+          "$$hashKey": "object:151",
           "alias": "TR Loss / h",
           "align": "auto",
           "colorMode": null,
@@ -271,6 +281,7 @@
           "unit": "lengthmi"
         },
         {
+          "$$hashKey": "object:152",
           "alias": "Start",
           "align": "auto",
           "colorMode": null,
@@ -285,12 +296,13 @@
           "linkTargetBlank": false,
           "linkUrl": "d/zm7wN6Zgz?from=${__cell_0}&to=${__cell_1}",
           "mappingType": 1,
-          "pattern": "start_date_mi",
+          "pattern": "start_date_us",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
+          "$$hashKey": "object:153",
           "alias": "End",
           "align": "auto",
           "colorMode": null,
@@ -302,12 +314,13 @@
           "dateFormat": "MM/DD/YY h:mm:ss a",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "end_date_mi",
+          "pattern": "end_date_us",
           "thresholds": [],
           "type": "date",
           "unit": "short"
         },
         {
+          "$$hashKey": "object:154",
           "alias": "TR Loss",
           "align": "auto",
           "colorMode": null,
@@ -325,6 +338,7 @@
           "unit": "lengthmi"
         },
         {
+          "$$hashKey": "object:155",
           "alias": "SOC",
           "align": "auto",
           "colorMode": null,
@@ -342,6 +356,7 @@
           "unit": "percent"
         },
         {
+          "$$hashKey": "object:156",
           "alias": "    ",
           "align": "auto",
           "colorMode": null,
@@ -361,10 +376,12 @@
           "unit": "short",
           "valueMaps": [
             {
+              "$$hashKey": "object:326",
               "text": "❄",
               "value": "1"
             },
             {
+              "$$hashKey": "object:327",
               "text": "",
               "value": "0"
             }
@@ -378,7 +395,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "with merge as (\n SELECT \n    c.start_date AS start_date,\n    c.end_date AS end_date,\n    c.start_ideal_range_km AS start_ideal_range_km,\n    c.end_ideal_range_km AS end_ideal_range_km,\n    c.start_rated_range_km AS start_rated_range_km,\n    c.end_rated_range_km AS end_rated_range_km,\n    start_battery_level,\n    end_battery_level,\n    p.usable_battery_level AS start_usable_battery_level,\n    NULL AS end_usable_battery_level,\n    p.odometer AS start_km,\n    p.odometer AS end_km\n FROM charging_processes c\n JOIN positions p ON c.position_id = p.id\n WHERE c.car_id = $car_id AND $__timeFilter(start_date)\n UNION\n SELECT \n    d.start_date AS start_date,\n    d.end_date AS end_date,\n    d.start_ideal_range_km AS start_ideal_range_km,\n    d.end_ideal_range_km AS end_ideal_range_km,\n    d.start_rated_range_km AS start_rated_range_km,\n    d.end_rated_range_km AS end_rated_range_km,\n    start_position.battery_level AS start_battery_level,\n    end_position.battery_level AS end_battery_level,\n    start_position.usable_battery_level AS start_usable_battery_level,\n    end_position.usable_battery_level AS end_usable_battery_level,\n    d.start_km AS start_km,\n    d.end_km AS end_km\n FROM drives d\n JOIN positions start_position ON d.start_position_id = start_position.id\n JOIN positions end_position ON d.end_position_id = end_position.id\n WHERE d.car_id = $car_id AND $__timeFilter(start_date)\n), \nv as (\n SELECT\n    lag(t.end_date) OVER w AS start_date,\n    t.start_date AS end_date,\n    lag(t.end_[[preferred_range]]_range_km) OVER w AS start_range,\n    t.start_[[preferred_range]]_range_km AS end_range,\n    lag(t.end_km) OVER w AS start_km,\n    t.start_km AS end_km,\n    EXTRACT(EPOCH FROM age(t.start_date, lag(t.end_date) OVER w)) AS duration,\n    lag(t.end_battery_level) OVER w AS start_battery_level,\n    lag(t.end_usable_battery_level) OVER w AS start_usable_battery_level,\n\t\tstart_battery_level AS end_battery_level,\n\t\tstart_usable_battery_level AS end_usable_battery_level,\n\t\tstart_battery_level > COALESCE(start_usable_battery_level, start_battery_level) AS has_reduced_range\n  FROM merge t\n  WINDOW w AS (ORDER BY t.start_date ASC)\n  ORDER BY start_date DESC\n)\n\nSELECT\n  round(extract(epoch FROM v.start_date)) * 1000 AS start_date_ts,\n  round(extract(epoch FROM v.end_date)) * 1000 AS end_date_ts,\n  -- Columns\n  v.start_date as start_date_[[length_unit]],\n  v.end_date as end_date_[[length_unit]],\n  v.duration,\n  (coalesce(s_asleep.sleep, 0) + coalesce(s_offline.sleep, 0)) / v.duration as standby,\n\t-greatest(v.start_battery_level - v.end_battery_level, 0) as soc_diff,\n\tCASE WHEN has_reduced_range THEN 1 ELSE 0 END as has_reduced_range,\n\tconvert_km(CASE WHEN has_reduced_range THEN NULL ELSE (v.start_range - v.end_range)::numeric END, '$length_unit') AS range_diff_$length_unit,\n  CASE WHEN has_reduced_range THEN NULL ELSE (v.start_range - v.end_range) * c.efficiency END AS consumption,\n  CASE WHEN has_reduced_range THEN NULL ELSE ((v.start_range - v.end_range) * c.efficiency) / (v.duration / 3600) * 1000 END as avg_power,\n  convert_km(CASE WHEN has_reduced_range THEN NULL ELSE ((v.start_range - v.end_range) / (v.duration / 3600))::numeric END, '$length_unit') AS range_lost_per_hour_[[length_unit]]\nFROM v,\n  LATERAL (\n    SELECT EXTRACT(EPOCH FROM sum(age(s.end_date, s.start_date))) as sleep\n    FROM states s\n    WHERE\n      state = 'asleep' AND\n      v.start_date <= s.start_date AND s.end_date <= v.end_date AND\n      s.car_id = $car_id\n  ) s_asleep,\n  LATERAL (\n    SELECT EXTRACT(EPOCH FROM sum(age(s.end_date, s.start_date))) as sleep\n    FROM states s\n    WHERE\n      state = 'offline' AND\n      v.start_date <= s.start_date AND s.end_date <= v.end_date AND\n      s.car_id = $car_id\n  ) s_offline\nJOIN cars c ON c.id = $car_id\nWHERE\n  v.duration > ($duration * 60 * 60)\n  AND v.start_range - v.end_range >= 0\n  AND v.end_km - v.start_km < 1;",
+          "rawSql": "with merge as (\n SELECT \n    c.start_date AS start_date,\n    c.end_date AS end_date,\n    c.start_ideal_range_km AS start_ideal_range_km,\n    c.end_ideal_range_km AS end_ideal_range_km,\n    c.start_rated_range_km AS start_rated_range_km,\n    c.end_rated_range_km AS end_rated_range_km,\n    start_battery_level,\n    end_battery_level,\n    p.usable_battery_level AS start_usable_battery_level,\n    NULL AS end_usable_battery_level,\n    p.odometer AS start_km,\n    p.odometer AS end_km\n FROM charging_processes c\n JOIN positions p ON c.position_id = p.id\n WHERE c.car_id = $car_id AND $__timeFilter(start_date)\n UNION\n SELECT \n    d.start_date AS start_date,\n    d.end_date AS end_date,\n    d.start_ideal_range_km AS start_ideal_range_km,\n    d.end_ideal_range_km AS end_ideal_range_km,\n    d.start_rated_range_km AS start_rated_range_km,\n    d.end_rated_range_km AS end_rated_range_km,\n    start_position.battery_level AS start_battery_level,\n    end_position.battery_level AS end_battery_level,\n    start_position.usable_battery_level AS start_usable_battery_level,\n    end_position.usable_battery_level AS end_usable_battery_level,\n    d.start_km AS start_km,\n    d.end_km AS end_km\n FROM drives d\n JOIN positions start_position ON d.start_position_id = start_position.id\n JOIN positions end_position ON d.end_position_id = end_position.id\n WHERE d.car_id = $car_id AND $__timeFilter(start_date)\n), \nv as (\n SELECT\n    lag(t.end_date) OVER w AS start_date,\n    t.start_date AS end_date,\n    lag(t.end_[[preferred_range]]_range_km) OVER w AS start_range,\n    t.start_[[preferred_range]]_range_km AS end_range,\n    lag(t.end_km) OVER w AS start_km,\n    t.start_km AS end_km,\n    EXTRACT(EPOCH FROM age(t.start_date, lag(t.end_date) OVER w)) AS duration,\n    lag(t.end_battery_level) OVER w AS start_battery_level,\n    lag(t.end_usable_battery_level) OVER w AS start_usable_battery_level,\n\t\tstart_battery_level AS end_battery_level,\n\t\tstart_usable_battery_level AS end_usable_battery_level,\n\t\tstart_battery_level > COALESCE(start_usable_battery_level, start_battery_level) AS has_reduced_range\n  FROM merge t\n  WINDOW w AS (ORDER BY t.start_date ASC)\n  ORDER BY start_date DESC\n)\n\nSELECT\n  round(extract(epoch FROM v.start_date)) * 1000 AS start_date_ts,\n  round(extract(epoch FROM v.end_date)) * 1000 AS end_date_ts,\n  -- Columns\n  v.start_date as start_date_[[date_format]],\n  v.end_date as end_date_[[date_format]],\n  v.duration,\n  (coalesce(s_asleep.sleep, 0) + coalesce(s_offline.sleep, 0)) / v.duration as standby,\n\t-greatest(v.start_battery_level - v.end_battery_level, 0) as soc_diff,\n\tCASE WHEN has_reduced_range THEN 1 ELSE 0 END as has_reduced_range,\n\tconvert_km(CASE WHEN has_reduced_range THEN NULL ELSE (v.start_range - v.end_range)::numeric END, '$length_unit') AS range_diff_$length_unit,\n  CASE WHEN has_reduced_range THEN NULL ELSE (v.start_range - v.end_range) * c.efficiency END AS consumption,\n  CASE WHEN has_reduced_range THEN NULL ELSE ((v.start_range - v.end_range) * c.efficiency) / (v.duration / 3600) * 1000 END as avg_power,\n  convert_km(CASE WHEN has_reduced_range THEN NULL ELSE ((v.start_range - v.end_range) / (v.duration / 3600))::numeric END, '$length_unit') AS range_lost_per_hour_[[length_unit]]\nFROM v,\n  LATERAL (\n    SELECT EXTRACT(EPOCH FROM sum(age(s.end_date, s.start_date))) as sleep\n    FROM states s\n    WHERE\n      state = 'asleep' AND\n      v.start_date <= s.start_date AND s.end_date <= v.end_date AND\n      s.car_id = $car_id\n  ) s_asleep,\n  LATERAL (\n    SELECT EXTRACT(EPOCH FROM sum(age(s.end_date, s.start_date))) as sleep\n    FROM states s\n    WHERE\n      state = 'offline' AND\n      v.start_date <= s.start_date AND s.end_date <= v.end_date AND\n      s.car_id = $car_id\n  ) s_offline\nJOIN cars c ON c.id = $car_id\nWHERE\n  v.duration > ($duration * 60 * 60)\n  AND v.start_range - v.end_range >= 0\n  AND v.end_km - v.start_km < 1;",
           "refId": "A",
           "select": [
             [
@@ -416,11 +433,12 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars;",
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "Car",
@@ -445,6 +463,7 @@
           "text": "6",
           "value": "6"
         },
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "min. Idle Time (h)",
@@ -495,11 +514,12 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "km",
-          "value": "km"
+          "text": "mi",
+          "value": "mi"
         },
         "datasource": "TeslaMate",
         "definition": "select unit_of_length from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -521,11 +541,12 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "ideal",
-          "value": "ideal"
+          "text": "rated",
+          "value": "rated"
         },
         "datasource": "TeslaMate",
         "definition": "select preferred_range from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -552,6 +573,7 @@
         },
         "datasource": "TeslaMate",
         "definition": "select base_url from settings limit 1;",
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -559,6 +581,33 @@
         "name": "base_url",
         "options": [],
         "query": "select base_url from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "us",
+          "value": "us"
+        },
+        "datasource": "TeslaMate",
+        "definition": "select date_format from settings limit 1;",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "date_format",
+        "options": [],
+        "query": "select date_format from settings limit 1;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/lib/teslamate/settings/global_settings.ex
+++ b/lib/teslamate/settings/global_settings.ex
@@ -6,6 +6,8 @@ defmodule TeslaMate.Settings.GlobalSettings do
     field :unit_of_length, Ecto.Enum, values: [:km, :mi]
     field :unit_of_temperature, Ecto.Enum, values: [:C, :F]
 
+    field :date_format, Ecto.Enum, values: [:ISO, :US]
+
     field :preferred_range, Ecto.Enum, values: [:ideal, :rated]
 
     field :base_url, :string
@@ -86,6 +88,7 @@ defmodule TeslaMate.Settings.GlobalSettings do
     |> cast(attrs, [
       :unit_of_length,
       :unit_of_temperature,
+      :date_format,
       :preferred_range,
       :base_url,
       :grafana_url,
@@ -94,6 +97,7 @@ defmodule TeslaMate.Settings.GlobalSettings do
     |> validate_required([
       :unit_of_length,
       :unit_of_temperature,
+      :date_format,
       :preferred_range,
       :language
     ])

--- a/lib/teslamate_web/live/settings_live/index.html.leex
+++ b/lib/teslamate_web/live/settings_live/index.html.leex
@@ -230,6 +230,27 @@ end %>
 
   <div class="columns is-mobile is-centered">
     <div class="column">
+      <h2 class="title is-4"><%= gettext("Dates") %></h2>
+      <div class="field is-horizontal">
+        <div class="field-label is-normal">
+          <%= label f, :date_format, gettext("Date Format"), class: "label" %>
+        </div>
+        <div class="field-body">
+          <div class="field">
+            <div class="control">
+              <div class="select is-fullwidth">
+                <%= select(f, :date_format, [{gettext("European or ISO: YYYY-MM-DD"), :ISO}, {gettext("American: MM/DD/YY"), :US}]) %>
+              </div>
+            </div>
+            <p class="help is-danger"><%= error_tag(f, :date_format) %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="columns is-mobile is-centered">
+    <div class="column">
       <h2 class="title is-4"><%= gettext("URLs") %></h2>
       <div class="field is-horizontal center-vertically">
         <div class="field-label is-normal">

--- a/priv/repo/migrations/20210325210433_create_date_format.exs
+++ b/priv/repo/migrations/20210325210433_create_date_format.exs
@@ -1,0 +1,19 @@
+defmodule TeslaMate.Repo.Migrations.CreateDateFormat do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE TYPE date_formats AS ENUM ('ISO', 'US')")
+
+    alter table(:settings) do
+      add(:date_format, :date_formats, default: "ISO", null: false)
+    end
+  end
+
+  def down do
+    alter table(:settings) do
+      remove(:date_format)
+    end
+
+    execute("DROP TYPE IF EXISTS date_formats")
+  end
+end


### PR DESCRIPTION
Split out from the previous change to facilitate further development

Added Date format (American/European) to settings screen and standardised date formats on dashboards that show them. This gets around the fact hat some of the dashboards were using the distance unit to set the date format.

There are two exceptions to this.

Dashboard "States" - Not possible to calculate a format on the fly due to a restriction on the Stats panel in Grafana.
Dashboard "Statistics" - New variable for date_format created, however the SQL needs reviewing by somebody who understands it. Aka, not me.
Dashboard "Dutch Tax" - This uses the local setting so will always render the date in the users local format.

Once the Grafana plugins have updated fully by the Grafana team to the new standard it should be possible to use date time local for all dashboards. Based on the progress of the Grafana team this could be a while away.