### PR TITLE
Confusing typo for binary_sensor heading in home_assistant.md

### DIFF
--- a/website/docs/integrations/home_assistant.md
+++ b/website/docs/integrations/home_assistant.md
@@ -336,7 +336,7 @@ tesla_location:
    icon: mdi:clock-outline
 ```
 
-### binary_sensor.yaml (sensor: section of configuration.yaml)
+### binary_sensor.yaml (binary_sensor: section of configuration.yaml)
 
 ```yml title="binary_sensor.yaml"
  - platform: template


### PR DESCRIPTION
Fixed heading of the **binary_sensor** config. 

Old one caused some slight confusion while doing my own setup, as I tried adding it in the stated **"sensor:"** section first.