### PR TITLE
Update permissions to the grafana plugin directory

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -16,7 +16,9 @@ USER root
 RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.2 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-discrete-panel 0.1.0 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install grafana-piechart-panel 1.6.1 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/grafana-map-panel/releases/download/0.15.0/grafana-map-panel-0.15.0.zip plugins install grafana-worldmap-panel-ng
+    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/grafana-map-panel/releases/download/0.15.0/grafana-map-panel-0.15.0.zip plugins install grafana-worldmap-panel-ng && \
+    chown -R "grafana" "${GF_PATHS_PLUGINS}" && \
+    chmod -R 777 "${GF_PATHS_PLUGINS}"
 
 USER grafana
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -13,14 +13,15 @@ ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
 
 USER root
 
+RUN mkdir -p "$GF_PATHS_PLUGINS" && \
+    chown -R grafana "$GF_PATHS_PLUGINS"
+
+USER grafana
+
 RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.2 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-discrete-panel 0.1.0 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install grafana-piechart-panel 1.6.1 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/grafana-map-panel/releases/download/0.15.0/grafana-map-panel-0.15.0.zip plugins install grafana-worldmap-panel-ng && \
-    chown -R "grafana" "${GF_PATHS_PLUGINS}" && \
-    chmod -R 777 "${GF_PATHS_PLUGINS}"
-
-USER grafana
+    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/grafana-map-panel/releases/download/0.15.0/grafana-map-panel-0.15.0.zip plugins install grafana-worldmap-panel-ng
 
 COPY logo.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY favicon.png /usr/share/grafana/public/img/fav32.png


### PR DESCRIPTION
Based on the existing docker image where plugins is owned by grafana, chmod 777.
(lines 77 and 78 of https://github.com/grafana/grafana/blob/main/Dockerfile)

This then allows the use the base GF_INSTALL_PLUGINS environment variable.