### PR TITLE
Minor correction docker-compose.yaml

### DIFF
--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -32,8 +32,9 @@ This setup is recommended only if you are running TeslaMate **on your home netwo
          - MQTT_HOST=mosquitto
        ports:
          - 4000:4000
-       volumes:
-         - ./import:/opt/app/import
+# Uncomment the following lines if you have an "import" folder in the same folder as the docker-compose.yaml file
+#       volumes:
+#         - ./import:/opt/app/import
        cap_drop:
          - all
 


### PR DESCRIPTION
Commented the `volumes` configuration for the `teslamate` container since the following error will appear if you do not have an `import` folder in the same directory as the `docker-compose.yaml` file:

```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: <path to docker-compose.yaml>/import
```

I only commented rather than removed so that it is easier to restore if a new user is importing data from another system.

An alternative approach is to add a step to the instructions after creating the `docker-compose.yaml` to create the `import` folder. However, I chose this approach instead since its a bit harder to deploy that way if you're using Portainer to add the stack (which is what I was doing).

Recreated error on both Ubuntu Server 20.04 using Portainer and Docker for OSX.