### PR TITLE
Add note with custom TM_DB_USER when backing up

### DIFF
--- a/website/docs/maintenance/backup_restore.md
+++ b/website/docs/maintenance/backup_restore.md
@@ -22,6 +22,10 @@ Be absolutely certain to move the `teslamate.bck` file to another safe location,
 If you get the error `No such service: database`, update your _docker-compose.yml_ or use `db` instead of `database` in the above command.
 :::
 
+:::note
+If you changed `TM_DB_USER` in the .env file from one of the advanced guides, make sure to replace the first instance of `teslamate` to the value of `TM_DB_USER` in the above command. 
+:::
+
 ## Restore
 
 :::note


### PR DESCRIPTION
I was trying to backup my TeslaMate instance, and tried using the command given in the documentation. I kept getting this error:

```
pg_dump: error: connection to database "teslamate" failed: FATAL:  role "teslamate" does not exist
```

However when I was setting up TeslaMate with [this guide](https://docs.teslamate.org/docs/guides/traefik), I changed the values in the `.env` file, specifically `TM_DB_USER`. Since I changed that, I needed to change it in the backup command also.

I added another little note box for others in this scenario.