### PR TITLE
Update grafana rule to limit to teslamate host

### DIFF
--- a/website/docs/guides/traefik.md
+++ b/website/docs/guides/traefik.md
@@ -94,7 +94,7 @@ services:
       - "traefik.http.middlewares.redirect.redirectscheme.scheme=https"
       - "traefik.http.routers.grafana-insecure.rule=Host(`${FQDN_TM}`)"
       - "traefik.http.routers.grafana-insecure.middlewares=redirect"
-      - "traefik.http.routers.grafana.rule=Path(`/grafana`) || PathPrefix(`/grafana/`)"
+      - "traefik.http.routers.grafana.rule=Host(`${FQDN_TM}`) && (Path(`/grafana`) || PathPrefix(`/grafana/`))"
       - "traefik.http.routers.grafana.entrypoints=websecure"
       - "traefik.http.routers.grafana.tls.certresolver=tmhttpchallenge"
 


### PR DESCRIPTION
useful if you share an already running traefik or have multiple domain