### PR TITLE
Fix typos in suspend tests

### DIFF
--- a/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_logging_test.exs
@@ -50,7 +50,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if vehicle is preconditioning", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         climate_state: %{is_preconditioning: true}
@@ -58,7 +58,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)
@@ -70,7 +70,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if user is present", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{is_user_present: true, car_version: ""}
@@ -78,7 +78,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)
@@ -90,7 +90,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if sentry mode is active", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{sentry_mode: true, car_version: ""}
@@ -98,7 +98,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)
@@ -110,7 +110,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if vehicle is unlocked", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{locked: false, car_version: ""}
@@ -118,7 +118,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events, settings: %{req_not_unlocked: true})
@@ -129,7 +129,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if any of the doors are open", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{df: 0, dr: 0, pf: 1, pr: 0, car_version: ""}
@@ -137,7 +137,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events, settings: %{req_not_unlocked: true})
@@ -148,7 +148,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if the rear or front trunk is open", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{rt: 1, ft: 1, car_version: ""}
@@ -156,7 +156,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events, settings: %{req_not_unlocked: true})
@@ -167,12 +167,12 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if shift_state is D", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(drive_state: %{timestamp: 0, shift_state: "D", latitude: 0.0, longitude: 0.0})
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)
@@ -183,12 +183,12 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if shift_state is R", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(drive_state: %{timestamp: 0, shift_state: "R", latitude: 0.0, longitude: 0.0})
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)
@@ -199,12 +199,12 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendLoggingTest do
   end
 
   test "cannot be suspended if shift_state is N", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(drive_state: %{timestamp: 0, shift_state: "N", latitude: 0.0, longitude: 0.0})
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
     :ok = start_vehicle(name, events)

--- a/test/teslamate/vehicles/vehicle/suspend_test.exs
+++ b/test/teslamate/vehicles/vehicle/suspend_test.exs
@@ -111,7 +111,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
   @tag :capture_log
   test "does not suspend if preconditioning", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         climate_state: %{is_preconditioning: true}
@@ -119,16 +119,16 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
-    sudpend_after_idle_ms = 10
+    suspend_after_idle_ms = 10
     suspend_ms = 100
 
     :ok =
       start_vehicle(name, events,
         settings: %{
-          suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
           suspend_min: suspend_ms
         }
       )
@@ -144,7 +144,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
   @tag :capture_log
   test "does not suspend if user is present", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{is_user_present: true, car_version: ""}
@@ -152,16 +152,16 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
-    sudpend_after_idle_ms = 10
+    suspend_after_idle_ms = 10
     suspend_ms = 100
 
     :ok =
       start_vehicle(name, events,
         settings: %{
-          suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
           suspend_min: suspend_ms
         }
       )
@@ -176,7 +176,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
   end
 
   test "does not suspend if sentry mode is active", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{sentry_mode: true, car_version: ""}
@@ -184,16 +184,16 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
-    sudpend_after_idle_ms = 10
+    suspend_after_idle_ms = 10
     suspend_ms = 100
 
     :ok =
       start_vehicle(name, events,
         settings: %{
-          suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
           suspend_min: suspend_ms
         }
       )
@@ -211,7 +211,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
   @tag :capture_log
   test "does not suspend if any of the doors are open", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{df: 0, dr: 0, pf: 1, pr: 0, car_version: ""}
@@ -219,16 +219,16 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
-    sudpend_after_idle_ms = 10
+    suspend_after_idle_ms = 10
     suspend_ms = 100
 
     :ok =
       start_vehicle(name, events,
         settings: %{
-          suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
           suspend_min: suspend_ms
         }
       )
@@ -246,7 +246,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
   @tag :capture_log
   test "does not suspend if the rear or front trunk is open", %{test: name} do
-    not_supendable =
+    not_suspendable =
       online_event(
         drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
         vehicle_state: %{rt: 0, ft: 1, car_version: ""}
@@ -254,16 +254,16 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
     events = [
       {:ok, online_event()},
-      {:ok, not_supendable}
+      {:ok, not_suspendable}
     ]
 
-    sudpend_after_idle_ms = 10
+    suspend_after_idle_ms = 10
     suspend_ms = 100
 
     :ok =
       start_vehicle(name, events,
         settings: %{
-          suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+          suspend_after_idle_min: round(suspend_after_idle_ms / 60),
           suspend_min: suspend_ms
         }
       )
@@ -473,7 +473,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
   describe "req_not_unlocked" do
     @tag :capture_log
     test "does not suspend if vehicle is unlocked", %{test: name} do
-      not_supendable =
+      not_suspendable =
         online_event(
           drive_state: %{timestamp: 0, latitude: 0.0, longitude: 0.0},
           vehicle_state: %{locked: false, car_version: ""}
@@ -481,17 +481,17 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
 
       events = [
         {:ok, online_event()},
-        {:ok, not_supendable}
+        {:ok, not_suspendable}
       ]
 
-      sudpend_after_idle_ms = 10
+      suspend_after_idle_ms = 10
       suspend_ms = 100
 
       :ok =
         start_vehicle(name, events,
           settings: %{
             req_not_unlocked: true,
-            suspend_after_idle_min: round(sudpend_after_idle_ms / 60),
+            suspend_after_idle_min: round(suspend_after_idle_ms / 60),
             suspend_min: suspend_ms
           }
         )
@@ -511,7 +511,7 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
     test "w/o does suspend if vehicle is unlocked", %{test: name} do
       now_ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
-      not_supendable = fn ts ->
+      not_suspendable = fn ts ->
         online_event(
           drive_state: %{timestamp: ts, latitude: 0.0, longitude: 0.0},
           vehicle_state: %{locked: false, car_version: ""}
@@ -519,19 +519,19 @@ defmodule TeslaMate.Vehicles.Vehicle.SuspendTest do
       end
 
       events = [
-        {:ok, not_supendable.(now_ts + 0)},
-        {:ok, not_supendable.(now_ts + 1)},
-        {:ok, not_supendable.(now_ts + 2)},
-        {:ok, not_supendable.(now_ts + 3)},
-        {:ok, not_supendable.(now_ts + 4)},
-        {:ok, not_supendable.(now_ts + 5)},
-        {:ok, not_supendable.(now_ts + 6)},
-        {:ok, not_supendable.(now_ts + 7)},
-        {:ok, not_supendable.(now_ts + 8)},
-        {:ok, not_supendable.(now_ts + 9)},
-        {:ok, not_supendable.(now_ts + 10)},
-        {:ok, not_supendable.(now_ts + 11)},
-        {:ok, not_supendable.(now_ts + 12)},
+        {:ok, not_suspendable.(now_ts + 0)},
+        {:ok, not_suspendable.(now_ts + 1)},
+        {:ok, not_suspendable.(now_ts + 2)},
+        {:ok, not_suspendable.(now_ts + 3)},
+        {:ok, not_suspendable.(now_ts + 4)},
+        {:ok, not_suspendable.(now_ts + 5)},
+        {:ok, not_suspendable.(now_ts + 6)},
+        {:ok, not_suspendable.(now_ts + 7)},
+        {:ok, not_suspendable.(now_ts + 8)},
+        {:ok, not_suspendable.(now_ts + 9)},
+        {:ok, not_suspendable.(now_ts + 10)},
+        {:ok, not_suspendable.(now_ts + 11)},
+        {:ok, not_suspendable.(now_ts + 12)},
         fn -> Process.sleep(10_000) end
       ]
 


### PR DESCRIPTION
This is a simple typo fixing pr. No functionality should be changed.