### PR TITLE
Added Apple mobile web app capable meta tag

### DIFF
--- a/lib/teslamate_web/templates/layout/root.html.heex
+++ b/lib/teslamate_web/templates/layout/root.html.heex
@@ -12,6 +12,7 @@
     <link rel="manifest" href="/site.webmanifest?v=5AB53N3ALo" crossorigin="use-credentials">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=5AB53N3ALo" color="#363636">
     <link rel="shortcut icon" href="/favicon.ico?v=5AB53N3ALo">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="theme-color" content="#ffffff">
     <%= csrf_meta_tag() %>


### PR DESCRIPTION
Enable to run the website in full screen mode on iPhones. This is useful in combination when starting TeslaMate with an app icon from the home screen.