### PR TITLE
Add datasource to table and map panels.

### DIFF
--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -763,6 +763,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Charges",
       "transformations": [
         {

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -805,6 +805,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Drive",
       "transformations": [
         {

--- a/grafana/dashboards/internal/charge-details.json
+++ b/grafana/dashboards/internal/charge-details.json
@@ -443,6 +443,7 @@
     },
     {
       "autoZoom": true,
+      "datasource": "TeslaMate",
       "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 15,

--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -571,6 +571,7 @@
     },
     {
       "autoZoom": true,
+      "datasource": "TeslaMate",
       "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 27,

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -1575,6 +1575,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Drives",
       "transformations": [],
       "type": "table"
@@ -2067,6 +2068,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Charges",
       "transformations": [
         {

--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -595,6 +595,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Updates",
       "type": "table"
     }

--- a/grafana/dashboards/vampire-drain.json
+++ b/grafana/dashboards/vampire-drain.json
@@ -545,6 +545,7 @@
           ]
         }
       ],
+      "datasource": "TeslaMate",
       "title": "Vampire Drain",
       "transformations": [
         {

--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -60,6 +60,7 @@
     },
     {
       "autoZoom": true,
+      "datasource": "TeslaMate",
       "defaultLayer": "OpenStreetMap",
       "gridPos": {
         "h": 21,
@@ -227,6 +228,7 @@
     ]
   },
   "timezone": "",
+  "datasource": "TeslaMate",
   "title": "Visited",
   "uid": "RG_DxSmgk",
   "version": 1,


### PR DESCRIPTION
This is a bit of a niche case - I integrate TeslaMate with an existing Grafana installation, which has a different datasource as the default. With the most recent release the table panels just displayed "No Data", and the map panels just displayed the world.

It took a while to debug, but I think it came down to the datasource not being specified correctly, and using the default - if that's not the default TeslaMate connection then you get no data.

Grafana don't specify their panel json format, so it's hard to know what the correct fix is. This change is pretty minimal and fixes the issue for me, so I wanted to submit in case it's useful to others. I've not tested it in a more standard installation, but I presume it will work ok.