### PR TITLE
Update vehicle.ex

### DIFF
--- a/lib/tesla_api/vehicle.ex
+++ b/lib/tesla_api/vehicle.ex
@@ -95,7 +95,7 @@ defmodule TeslaApi.Vehicle do
       %Tesla.Env{status: 405, body: %{"error" => "vehicle is currently in service"}} = env ->
         {:error, %Error{reason: :vehicle_in_service, env: env}}
 
-      %Tesla.Env{status: 408, body: %{"error" => "vehicle unavailable:" <> _}} = env ->
+      %Tesla.Env{status: 408, body: %{"error" => "vehicle asleep" <> _}} = env ->
         {:error, %Error{reason: :vehicle_unavailable, env: env}}
 
       %Tesla.Env{status: 504} = env ->


### PR DESCRIPTION
Would it make sense to update the `408` error response per the conversation in #2413? If not, feel free to reject the PR. Chatted with Tyler over at TeslaScope and he mentioned `408` error is when the vehicle is sleeping
![Screen Shot 2022-02-01 at 9 28 11 AM](https://user-images.githubusercontent.com/54645561/151997936-44936051-a419-4b36-928e-38aa2f1c670b.png)