### PR TITLE
add dataSource where needed

### DIFF
--- a/grafana/dashboards/charges.json
+++ b/grafana/dashboards/charges.json
@@ -58,6 +58,7 @@
       "type": "row"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -698,6 +698,7 @@
       "type": "piechart"
     },
     {
+      "datasource": "TeslaMate",
       "autoPanLabels": true,
       "autoWidthLabels": true,
       "categories": "a,b",
@@ -767,7 +768,6 @@
       },
       "targets": [
         {
-          "datasource": "TeslaMate",
           "format": "table",
           "group": [],
           "metricColumn": "none",

--- a/grafana/dashboards/drives.json
+++ b/grafana/dashboards/drives.json
@@ -59,6 +59,7 @@
       "type": "row"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -1209,6 +1209,7 @@
       "type": "state-timeline"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1580,6 +1581,7 @@
       "type": "table"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/updates.json
+++ b/grafana/dashboards/updates.json
@@ -205,6 +205,7 @@
       "type": "stat"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -566,7 +567,6 @@
       ],
       "targets": [
         {
-          "datasource": "TeslaMate",
           "format": "table",
           "group": [],
           "metricColumn": "none",

--- a/grafana/dashboards/vampire-drain.json
+++ b/grafana/dashboards/vampire-drain.json
@@ -59,6 +59,7 @@
       "type": "row"
     },
     {
+      "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/visited.json
+++ b/grafana/dashboards/visited.json
@@ -61,6 +61,7 @@
     {
       "autoZoom": true,
       "defaultLayer": "OpenStreetMap",
+      "datasource": "TeslaMate",
       "gridPos": {
         "h": 21,
         "w": 24,
@@ -76,7 +77,6 @@
       "showLayerChanger": true,
       "targets": [
         {
-          "datasource": "TeslaMate",
           "format": "time_series",
           "group": [],
           "metricColumn": "none",


### PR DESCRIPTION
In situations where the `TeslaMate` datasource is not the default datasource for grafana, it is necessary to properly denote the `TeslaMate` datasource for panel scopes to include FieldConfig as well as some map panel types.

