### PR TITLE
moved subselects to "from" clause

### DIFF
--- a/grafana/dashboards/drive-stats.json
+++ b/grafana/dashboards/drive-stats.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1598012944784,
+  "id": 13,
+  "iteration": 1644505954964,
   "links": [
     {
       "icon": "dashboard",
@@ -906,7 +907,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "WITH first_position AS (\n\tSELECT date, odometer\n\tFROM positions\n\tWHERE car_id = $car_id AND $__timeFilter(date)\n\tORDER BY date ASC\n\tLIMIT 1\n),\nlast_position AS (\n\tSELECT date, odometer\n\tFROM positions\n\tWHERE car_id = $car_id AND $__timeFilter(date)\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT\n\tconvert_km((((SELECT odometer FROM last_position) - (SELECT odometer\tFROM first_position)) /\n\tEXTRACT(days FROM (SELECT date FROM last_position) - (SELECT date\tFROM first_position)) * \n\t365)::numeric, '$length_unit') AS \"mileage_$length_unit\";",
+          "rawSql": "WITH first_position AS (\n\tSELECT date, odometer\n\tFROM positions\n\tWHERE car_id = $car_id AND $__timeFilter(date)\n\tORDER BY date ASC\n\tLIMIT 1\n),\nlast_position AS (\n\tSELECT date, odometer\n\tFROM positions\n\tWHERE car_id = $car_id AND $__timeFilter(date)\n\tORDER BY date DESC\n\tLIMIT 1\n)\nSELECT\n\tconvert_km(((lp.odometer - fp.odometer) /\n\tEXTRACT(days FROM lp.date - fp.date) * \n\t365)::numeric, '$length_unit') AS \"mileage_$length_unit\" from first_position as fp, last_position as lp;",
           "refId": "A",
           "select": [
             [
@@ -1200,5 +1201,5 @@
   "timezone": "",
   "title": "Drive Stats",
   "uid": "_7WkNSyWk",
-  "version": 1
+  "version": 48
 }

--- a/grafana/dashboards/drive-stats.json
+++ b/grafana/dashboards/drive-stats.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 13,
   "iteration": 1644505954964,
   "links": [
     {
@@ -1201,5 +1200,5 @@
   "timezone": "",
   "title": "Drive Stats",
   "uid": "_7WkNSyWk",
-  "version": 48
+  "version": 1
 }


### PR DESCRIPTION
just a small simplification on the estimated mileage calculation

instead of 4 subselects I've moved  the tables to the "from" clause.

From:
```SQL
SELECT
	convert_km((((SELECT odometer FROM last_position) - (SELECT odometer	FROM first_position)) /
	EXTRACT(days FROM (SELECT date FROM last_position) - (SELECT date	FROM first_position)) * 
	365)::numeric, '$length_unit') AS "mileage_$length_unit";
```

To:

```SQL
SELECT
	convert_km(((lp.odometer - fp.odometer) /
	EXTRACT(days FROM lp.date - fp.date) * 
	365)::numeric, '$length_unit') AS "mileage_$length_unit" from first_position as fp, last_position as lp;
```