### PR TITLE
Render Trip piechart legend

### DIFF
--- a/grafana/dashboards/trip.json
+++ b/grafana/dashboards/trip.json
@@ -341,7 +341,7 @@
         ],
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom",
           "values": [
             "value"


### PR DESCRIPTION
Per discussion #2469, looks like the legend got removed. This adds it back as a list.