### PR TITLE
Update Charging Stats panel styling

### DIFF
--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -409,7 +409,7 @@
       "id": 26,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {


### PR DESCRIPTION
Updates the `Cost per 100 $length` panel to not be small text. PR contains before and after screenshots. Makes for consistent formatting across dashboard.

Before
![Screen Shot 2022-02-18 at 3 50 06 PM](https://user-images.githubusercontent.com/54645561/154765989-6152e73a-13b7-4579-a759-8f3a817d931d.png)

After
![Screen Shot 2022-02-18 at 3 49 45 PM](https://user-images.githubusercontent.com/54645561/154765952-dba8d096-1cd5-4338-aad4-22b1048920d6.png)

