### PR TITLE
Display marketing names for Model S and X

### DIFF
--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -58,7 +58,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
   defp put_friendly_name(nil), do: nil
 
   defp put_friendly_name(%Car{} = car) do
-    %Car{car | friendly_name: friendly_name(car.model, car.trim_badging)}
+    %Car{car | friendly_name: friendly_name(car.model, car.trim_badging, car.car_type)}
   end
 
   defp friendly_name("3", "P74D"), do: "LR AWD Performance"
@@ -68,6 +68,10 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
   defp friendly_name("3", "50"), do: "SR+"
   defp friendly_name("Y", "P74D"), do: "LR AWD Performance"
   defp friendly_name("Y", "74D"), do: "LR AWD"
+  defp friendly_name("S", "100D", "lychee"), do: "LR"
+  defp friendly_name("S", "P100D", "lychee"), do: "Plaid"
+  defp friendly_name("X", "100D", "tamarind"), do: "LR"
+  defp friendly_name("X", "P100D", "tamarind"), do: "Plaid"  
   defp friendly_name(_model, _trim), do: nil
 
   defp format_state({:driving, {:offline, _}, _id}), do: :offline


### PR DESCRIPTION
All stemming from #2494 - I am going to make this pull request fully knowing it either will be rejected (totally OK) or require some additional work to get it working.

I am not at all close to knowing where the `car.model` or `car.trim_badging` comes from. But I do know to get the right Model S designations, we need to know the `car.car_type`. As such, we need to add this into the logic for lines 64 through 71 (before changes). Also need to add it to line 61 (I believe) to check for this data. **However**, I have no clue what is going to happen to the Model 3 and Y logic that is there if we do not add the `car_type` matching data to those lines (64 - 71). I also have no clue if my modifications would work either. Or if there would just have to be repetitive checks for the 3 and Y, because `car.model` already equals 3 / Y and `car.car_type` also equals 3 / Y (per this comment https://github.com/adriankumpf/teslamate/issues/2494#issuecomment-1049360750)

But to get the right Model S (And X) names, we need not only the `car.model`, we need the `car.car_type` attribute as well  since they started updating `car_type` with the 2021.5 refresh. Because there is a 100D and P100D Model S and X, now they are reusing the 100D designation but changed the `car_type` for the refreshed Model S and X - hence the other two PRs - #2455 and #2431 

So I took at stab at it.