### PR TITLE
Fix charging-stats for better "Charge deltas" when the charging process is interrupted and re-started

### DIFF
--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -587,7 +587,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__time(start_date),\n\tstart_battery_level,\n\tend_battery_level\nFROM\n\tcharging_processes\nWHERE\n\t$__timeFilter(start_date)\n\tAND duration_min > 3\n\tAND car_id = $car_id\nORDER BY\n\tstart_date;",
+          "rawSql": "SELECT\n\t$__timeGroup(start_date,'2h') as time,\n\tMIN(start_battery_level) as start_battery_level,\n\tMAX(end_battery_level) as end_battery_level\nFROM\n\tcharging_processes\nWHERE\n\t$__timeFilter(start_date)\n\tAND duration_min > 3\n\tAND car_id = $car_id\nGROUP BY\n\t1\nORDER BY\n\t1;",
           "refId": "A",
           "select": [
             [


### PR DESCRIPTION
When the charging process is interrupted and re-started, you can see some "jumps" in the graph.
Right now the graph looks like this: 
![image](https://user-images.githubusercontent.com/118949/161226650-5523df93-0433-4177-8cde-f5c773e7c6fa.png)

With the new query, this is the result:
![image](https://user-images.githubusercontent.com/118949/161226565-b89a4275-c8e8-45c0-8c3b-879f4ac26c30.png)

To achieve this, the query is modified to aggregate charges within a few hours 

```sql
SELECT
	$__timeGroup(start_date,'2h') as time,
	MIN(start_battery_level) as start_battery_level,
	MAX(end_battery_level) as end_battery_level
FROM
	charging_processes
WHERE
	$__timeFilter(start_date)
	AND duration_min > 3
	AND car_id = $car_id
GROUP BY 
	1
ORDER BY
	1;
```