### PR TITLE
Add FAQ around Docker timestamp logs

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -54,3 +54,7 @@ teslamate_1     | 2021-03-16 12:03:28.139 car_id=1 [info] Disconnecting ...
 The problem with the polling mode is that the car does not fall asleep before it have been inactive for some 15 minutes. TeslaMate will suspend all polling after the car has been idle for 3 minutes (the 'Idle Time Before Trying to Sleep' setting), and will resume polling 15 minutes later (the 'Time to Try Sleeping' setting). Any activity during this 15 minutes can't be detected, as calling the [Vehicle Data API](https://www.teslaapi.io/vehicles/state-and-settings#vehicle-data) would reset the car's inactivity timer, preventing the car from falling asleep.
 
 Calling the [Vehicle API](https://www.teslaapi.io/vehicles/list#vehicle) does not reset the inactivity timer, but it only tells if the car is either online (driving, charging, idle, about to fall asleep) or asleep. It can't tell if an idle car started driving during the 'Time to Try Sleeping' period.
+
+## Why are my Docker timestamp logs different than my machine?
+
+Docker container timezones default to UTC. To set the timezone for your container, use the `TZ` Environment Variable in your YML file. More information found at [Enviornment Variables](https://docs.teslamate.org/docs/configuration/environment_variables)


### PR DESCRIPTION
This PR will add a FAQ around Docker container timestamp logs and why they differ from your machine if you do not configure the TZ environment variable.