### PR TITLE
Better Charging Stats -> Charge Delta

### DIFF
--- a/grafana/dashboards/charging-stats.json
+++ b/grafana/dashboards/charging-stats.json
@@ -588,7 +588,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n\t$__timeGroup(start_date,'2h') as time,\n\tMIN(start_battery_level) as start_battery_level,\n\tMAX(end_battery_level) as end_battery_level\nFROM\n\tcharging_processes\nWHERE\n\t$__timeFilter(start_date)\n\tAND duration_min > 3\n\tAND car_id = $car_id\nGROUP BY\n\t1\nORDER BY\n\t1;",
+          "rawSql": "WITH charges AS (\n\tSELECT\n\t\tstart_date,\n\t\tstart_battery_level,\n\t\tend_battery_level,\n\t\tp.odometer,\n\t\tCOALESCE(\n\t\t\tLAG(p.odometer) OVER (\n\t\t\t\tORDER BY cp.start_date\n\t\t\t),\n\t\t\tp.odometer\n\t\t) as odometer_prev\n\tFROM\n\t\tcharging_processes cp\n\tJOIN positions p\n\tON p.id = cp.position_id\n\tWHERE\n\t\t$__timeFilter(cp.start_date)\n\t\tAND cp.duration_min > 3\n\t\tAND cp.car_id = $car_id\n)\nSELECT\n\tMIN(start_date) as time,\n\tMIN(start_battery_level) as start_battery_level,\n\tMAX(end_battery_level) as end_battery_level\nFROM charges\nGROUP BY\n\tCASE WHEN odometer - odometer_prev < 2 THEN odometer_prev ELSE odometer END\nORDER BY\n\ttime;",
           "refId": "A",
           "select": [
             [


### PR DESCRIPTION
This change is to better handle multiple charges, one after the other.
By using the "odometer" we can see if the car actually didn't move much between charges (this happens for instance if you arrive at a charging point and only the "slow charger" is available, then the "fast" become available, and you can stop charging, switch and restart with the fast)

Before:

![image](https://user-images.githubusercontent.com/118949/169249596-a8a0931f-35d8-4218-97df-9c93be2dc5d0.png)

Now:

![image](https://user-images.githubusercontent.com/118949/169249547-0bd48621-f1fc-49f5-b61a-ba6da34a4404.png)
