### PR TITLE
Added tire pressure

### DIFF
--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -379,6 +379,123 @@
       "type": "stat"
     },
     {
+      "id": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "type": "graph",
+      "title": "Tire Pressure",
+      "pluginVersion": "8.3.4",
+      "links": [],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": true,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "lineStyle": {
+              "fill": "solid"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "mappings": [],
+          "decimals": 1,
+          "links": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "datasource": "TeslaMate",
+          "format": "time_series",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT\r\n    $__time(date),\r\n    convert_tire_pressure(tpms_pressure_fl,'$tire_pressure_units') AS tpms_pressure_front_left,\r\n    convert_tire_pressure(tpms_pressure_fr,'$tire_pressure_units') AS tpms_pressure_front_right,\r\n    convert_tire_pressure(tpms_pressure_rl,'$tire_pressure_units') AS tpms_pressure_rear_left,\r\n    convert_tire_pressure(tpms_pressure_rr,'$tire_pressure_units') AS tpms_pressure_rear_right\r\nFROM\r\n    positions\r\nWHERE\r\n    car_id = $car_id AND\r\n    $__timeFilter(date) AND\r\n    tpms_pressure_fl is not null\r\nORDER BY\r\n    date ASC",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "pos",
+          "timeColumn": "date",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "datasource": "TeslaMate"
+    },
+    {
       "datasource": "TeslaMate",
       "fieldConfig": {
         "defaults": {
@@ -1322,6 +1439,34 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "psi",
+          "value": "psi"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Tire Pressure Units",
+        "multi": false,
+        "name": "tire_pressure_units",
+        "options": [
+          {
+            "selected": false,
+            "text": "bar",
+            "value": "bar"
+          },
+          {
+            "selected": true,
+            "text": "psi",
+            "value": "psi"
+          }
+        ],
+        "query": "bar, psi",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
       },
       {
         "current": {

--- a/lib/tesla_api/vehicle/state.ex
+++ b/lib/tesla_api/vehicle/state.ex
@@ -298,7 +298,11 @@ defmodule TeslaApi.Vehicle.State do
       :timestamp,
       :valet_mode,
       :valet_pin_needed,
-      :vehicle_name
+      :vehicle_name,
+      :tpms_pressure_fl,
+      :tpms_pressure_fr,
+      :tpms_pressure_rl,
+      :tpms_pressure_rr
     ]
 
     defmodule SoftwareUpdate do
@@ -358,7 +362,11 @@ defmodule TeslaApi.Vehicle.State do
         sentry_mode_available: vehicle_state["sentry_mode_available"],
         smart_summon_available: vehicle_state["smart_summon_available"],
         valet_pin_needed: vehicle_state["valet_pin_needed"],
-        vehicle_name: vehicle_state["vehicle_name"]
+        vehicle_name: vehicle_state["vehicle_name"],
+        tpms_pressure_fl: vehicle_state["tpms_pressure_fl"],
+        tpms_pressure_fr: vehicle_state["tpms_pressure_fr"],
+        tpms_pressure_rl: vehicle_state["tpms_pressure_rl"],
+        tpms_pressure_rr: vehicle_state["tpms_pressure_rr"]
       }
     end
   end

--- a/lib/teslamate/log/position.ex
+++ b/lib/teslamate/log/position.ex
@@ -29,6 +29,10 @@ defmodule TeslaMate.Log.Position do
     field :is_climate_on, :boolean
     field :is_rear_defroster_on, :boolean
     field :is_front_defroster_on, :boolean
+    field :tpms_pressure_fl, :decimal
+    field :tpms_pressure_fr, :decimal
+    field :tpms_pressure_rl, :decimal
+    field :tpms_pressure_rr, :decimal
 
     belongs_to(:car, Car)
     belongs_to(:drive, Drive)
@@ -61,7 +65,11 @@ defmodule TeslaMate.Log.Position do
       :passenger_temp_setting,
       :is_climate_on,
       :is_rear_defroster_on,
-      :is_front_defroster_on
+      :is_front_defroster_on,
+      :tpms_pressure_fl,
+      :tpms_pressure_fr,
+      :tpms_pressure_rl,
+      :tpms_pressure_rr
     ])
     |> validate_required([:car_id, :date, :latitude, :longitude])
     |> foreign_key_constraint(:car_id)

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1261,7 +1261,11 @@ defmodule TeslaMate.Vehicles.Vehicle do
       is_front_defroster_on: vehicle.climate_state.is_front_defroster_on,
       battery_heater_on: vehicle.charge_state.battery_heater_on,
       battery_heater: vehicle.climate_state.battery_heater,
-      battery_heater_no_power: vehicle.climate_state.battery_heater_no_power
+      battery_heater_no_power: vehicle.climate_state.battery_heater_no_power,
+      tpms_pressure_fl: vehicle.vehicle_state.tpms_pressure_fl,
+      tpms_pressure_fr: vehicle.vehicle_state.tpms_pressure_fr,
+      tpms_pressure_rl: vehicle.vehicle_state.tpms_pressure_rl,
+      tpms_pressure_rr: vehicle.vehicle_state.tpms_pressure_rr
     }
 
     elevation =

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -13,7 +13,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     odometer shift_state charge_port_door_open time_to_full_charge charger_phases
     charger_actual_current charger_voltage version update_available update_version is_user_present geofence
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
-    charge_current_request charge_current_request_max
+    charge_current_request charge_current_request_max tpms_pressure_fl tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -118,7 +118,11 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       is_user_present: get_in_struct(vehicle, [:vehicle_state, :is_user_present]),
       version: version(vehicle),
       update_available: update_available(vehicle),
-      update_version: update_version(vehicle)
+      update_version: update_version(vehicle),
+      tpms_pressure_fl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fl]),
+      tpms_pressure_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fr]),
+      tpms_pressure_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rl]),
+      tpms_pressure_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rr]),
     }
   end
 

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -122,7 +122,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       tpms_pressure_fl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fl]),
       tpms_pressure_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_fr]),
       tpms_pressure_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rl]),
-      tpms_pressure_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rr]),
+      tpms_pressure_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_pressure_rr])
     }
   end
 

--- a/priv/repo/migrations/20220617161300_add_tire_pressures.exs
+++ b/priv/repo/migrations/20220617161300_add_tire_pressures.exs
@@ -1,0 +1,37 @@
+defmodule TeslaMate.Repo.Migrations.AddTirePressures do
+  use Ecto.Migration
+
+  def change do
+    alter table(:positions) do
+      add_if_not_exists(:tpms_pressure_fl, :numeric, precision: 4, scale: 1)
+      add_if_not_exists(:tpms_pressure_fr, :numeric, precision: 4, scale: 1)
+      add_if_not_exists(:tpms_pressure_rl, :numeric, precision: 4, scale: 1)
+      add_if_not_exists(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
+    end
+  end
+
+    def change do
+      execute("DROP FUNCTION IF EXISTS public.convert_tire_pressure(double precision, character varying);", &noop/0)
+
+      execute(
+        """
+        CREATE OR REPLACE FUNCTION public.convert_tire_pressure(n numeric(6,2), character varying)
+        RETURNS numeric(6,2)
+        LANGUAGE 'sql'
+        COST 100
+        VOLATILE
+        AS $BODY$
+        SELECT
+        CASE $2 WHEN 'bar' THEN $1
+          WHEN 'psi' THEN $1 * 14.503773773
+        END;
+        $BODY$;
+        """,
+        &noop/0
+      )
+
+  end
+
+  defp noop, do: :ok
+
+end

--- a/priv/repo/migrations/20220617170400_add_tire_pressures.exs
+++ b/priv/repo/migrations/20220617170400_add_tire_pressures.exs
@@ -8,9 +8,7 @@ defmodule TeslaMate.Repo.Migrations.AddTirePressures do
       add_if_not_exists(:tpms_pressure_rl, :numeric, precision: 4, scale: 1)
       add_if_not_exists(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
     end
-  end
 
-    def change do
       execute("DROP FUNCTION IF EXISTS public.convert_tire_pressure(double precision, character varying);", &noop/0)
 
       execute(
@@ -23,7 +21,7 @@ defmodule TeslaMate.Repo.Migrations.AddTirePressures do
         AS $BODY$
         SELECT
         CASE $2 WHEN 'bar' THEN $1
-          WHEN 'psi' THEN $1 * 14.503773773
+            WHEN 'psi' THEN $1 * 14.503773773
         END;
         $BODY$;
         """,

--- a/priv/repo/migrations/20220617170400_add_tire_pressures.exs
+++ b/priv/repo/migrations/20220617170400_add_tire_pressures.exs
@@ -3,31 +3,29 @@ defmodule TeslaMate.Repo.Migrations.AddTirePressures do
 
   def change do
     alter table(:positions) do
-      add(:tpms_pressure_fl, :numeric, precision: 4, scale: 1)
-      add(:tpms_pressure_fr, :numeric, precision: 4, scale: 1)
-      add(:tpms_pressure_rl, :numeric, precision: 4, scale: 1)
-      add(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
+      add :tpms_pressure_fl, :numeric, precision: 4, scale: 1
+      add :tpms_pressure_fr, :numeric, precision: 4, scale: 1
+      add :tpms_pressure_rl, :numeric, precision: 4, scale: 1
+      add :tpms_pressure_rr, :numeric, precision: 4, scale: 1
     end
 
-      execute(
-        """
-        CREATE OR REPLACE FUNCTION public.convert_tire_pressure(n numeric(6,2), character varying)
-        RETURNS numeric(6,2)
-        LANGUAGE 'sql'
-        COST 100
-        VOLATILE
-        AS $BODY$
-        SELECT
-        CASE $2 WHEN 'bar' THEN $1
-            WHEN 'psi' THEN $1 * 14.503773773
-        END;
-        $BODY$;
-        """,
-        &noop/0
-      )
-
+    execute(
+      """
+      CREATE OR REPLACE FUNCTION public.convert_tire_pressure(n numeric(6,2), character varying)
+      RETURNS numeric(6,2)
+      LANGUAGE 'sql'
+      COST 100
+      VOLATILE
+      AS $BODY$
+      SELECT
+      CASE $2 WHEN 'bar' THEN $1
+          WHEN 'psi' THEN $1 * 14.503773773
+      END;
+      $BODY$;
+      """,
+      &noop/0
+    )
   end
 
   defp noop, do: :ok
-
 end

--- a/priv/repo/migrations/20220617170400_add_tire_pressures.exs
+++ b/priv/repo/migrations/20220617170400_add_tire_pressures.exs
@@ -3,10 +3,10 @@ defmodule TeslaMate.Repo.Migrations.AddTirePressures do
 
   def change do
     alter table(:positions) do
-      add_if_not_exists(:tpms_pressure_fl, :numeric, precision: 4, scale: 1)
-      add_if_not_exists(:tpms_pressure_fr, :numeric, precision: 4, scale: 1)
-      add_if_not_exists(:tpms_pressure_rl, :numeric, precision: 4, scale: 1)
-      add_if_not_exists(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
+      add(:tpms_pressure_fl, :numeric, precision: 4, scale: 1)
+      add(:tpms_pressure_fr, :numeric, precision: 4, scale: 1)
+      add(:tpms_pressure_rl, :numeric, precision: 4, scale: 1)
+      add(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
     end
 
       execute("DROP FUNCTION IF EXISTS public.convert_tire_pressure(double precision, character varying);", &noop/0)

--- a/priv/repo/migrations/20220617170400_add_tire_pressures.exs
+++ b/priv/repo/migrations/20220617170400_add_tire_pressures.exs
@@ -9,8 +9,6 @@ defmodule TeslaMate.Repo.Migrations.AddTirePressures do
       add(:tpms_pressure_rr, :numeric, precision: 4, scale: 1)
     end
 
-      execute("DROP FUNCTION IF EXISTS public.convert_tire_pressure(double precision, character varying);", &noop/0)
-
       execute(
         """
         CREATE OR REPLACE FUNCTION public.convert_tire_pressure(n numeric(6,2), character varying)

--- a/website/docs/integrations/mqtt.md
+++ b/website/docs/integrations/mqtt.md
@@ -10,7 +10,7 @@ The MQTT function within TeslaMate allows useful values to be published to an MQ
 Vehicle data will be published to the following topics:
 
 | Topic                                                  | Example              | Description                                                                           |
-| ------------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------------- |
+|--------------------------------------------------------|----------------------|---------------------------------------------------------------------------------------|
 | `teslamate/cars/$car_id/display_name`                  | Blue Thunder         | Vehicle Name                                                                          |
 | `teslamate/cars/$car_id/state`                         | asleep               | Status of the vehicle (e.g. `online`, `asleep`, `charging`)                           |
 | `teslamate/cars/$car_id/since`                         | 2019-02-29T23:00:07Z | Date of the last status change                                                        |
@@ -67,6 +67,10 @@ Vehicle data will be published to the following topics:
 | `teslamate/cars/$car_id/charge_current_request_max`    | 40                   | How many amps the car can have                                                        |
 | `teslamate/cars/$car_id/scheduled_charging_start_time` | 2019-02-29T23:00:07Z | Start time of the scheduled charge                                                    |
 | `teslamate/cars/$car_id/time_to_full_charge`           | 1.83                 | Hours remaining to full charge                                                        |
+| `teslamate/cars/$car_id/tpms_pressure_fl`              | 2.9                  | Tire pressure measure in BAR, front left tire                                         |
+| `teslamate/cars/$car_id/tpms_pressure_fr`              | 2.8                  | Tire pressure measure in BAR, front right tire                                        |
+| `teslamate/cars/$car_id/tpms_pressure_rl`              | 2.9                  | Tire pressure measure in BAR, rear left tire                                          |
+| `teslamate/cars/$car_id/tpms_pressure_rr`              | 2.8                  | Tire pressure measure in BAR, rear right tire                                         |
 
 :::note
 `$car_id` usually starts at 1


### PR DESCRIPTION
Added new functionality to teslamate to record tire pressure via Tesla API. 
Tire pressure fields in the API was added by Tesla in 2022.4 version.
Added new panel in drive-internal dashboard to show the records of the tires. 
The recorded data is shown by Bar value and can be converted to PSI, by a new postgresql function
The result is shown in the picture below.

![image](https://user-images.githubusercontent.com/45952578/174315725-668f0169-52db-4f26-b7e3-17fd435b2080.png)