### PR TITLE
fix gpx format

### DIFF
--- a/lib/teslamate_web/templates/drive/gpx.xml.eex
+++ b/lib/teslamate_web/templates/drive/gpx.xml.eex
@@ -1,10 +1,13 @@
-<gpx version="1.1">
+<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" creator="Teslamate" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
     <trk>
         <name><%= DateTime.to_iso8601(@drive.start_date) %></name>
         <trkseg>
             <%= for position <- @drive.positions do %>
             <trkpt lat="<%= position.latitude %>" lon="<%= position.longitude %>">
+                <%= if not is_nil(position.elevation) do %>
                 <ele><%= position.elevation %></ele>
+                <% end %>
                 <time><%= DateTime.to_iso8601(position.date) %></time>
             </trkpt>
             <% end %>


### PR DESCRIPTION
Some tools, e.g. Garmin Basecamp,  are more sensitive to xml schema violations. This fixes three issues:

-  Use a proper namespace definition in the xml root element
- Track point elevation is specified to be an element of type xsd:decimal in the gpx schema. But Teslamate renders an empty element <ele></ele> when no elevation data is present. This fix does not render an <ele> element when no elevation is present as required by the schema. 
- The gpx schema requires a "creator" attribute on the gpx root element.

Note: I was not able to successfully run `mix test` even without my changes. However, the gpx-related tests still pass with and without my changes.
