### PR TITLE
Upgrade ex_cldr to 2.33.0 to fix compilation failure on elixir 1.14

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule TeslaMate.MixProject do
     [
       {:castore, "~> 0.1"},
       {:ecto_sql, "~> 3.0"},
-      {:ex_cldr, "~> 2.31.0"},
+      {:ex_cldr, "~> 2.33.0"},
       {:ex_cldr_plugs, "~> 1.0"},
       {:excoveralls, "~> 0.10", only: :test},
       {:finch, "~> 0.3"},


### PR DESCRIPTION
Fixes this problem https://github.com/elixir-cldr/cldr/issues/182

== Compilation error in file lib/myapp/cldr.ex ==
** (CompileError) lib/cldr/plural_rules/plural_rule.ex:1: undefined function mod/2 (expected MyApp.Cldr.Number.Ordinal to define such a function or for it to be imported, but none are available)
    (ex_cldr 2.32.1) ../umbrella/apps/myapp/lib/myapp/cldr.ex:1: Cldr.Backend.Compiler.__before_compile__/1
