### PR TITLE
Upgrade Grafana to version 9.3

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:latest
+FROM grafana/grafana:9.3.2
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     GF_AUTH_ANONYMOUS_ENABLED=false \

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:8.5.9
+FROM grafana/grafana:latest
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     GF_AUTH_ANONYMOUS_ENABLED=false \


### PR DESCRIPTION
The current `Dockerfile` for building Grafana is based on version 8.5.9, which is outdated.

Grafana 9 improves many things over 8, such as the ability to select the `smallint` type in the query builder, and version 9.3 is being very stable for my so far with Teslamate and the current settings and dashboards.