### PR TITLE
Bump pr0ps-trackmap-panel to 2.1.4

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 
 USER grafana
 
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/pR0Ps/grafana-trackmap-panel/releases/download/v2.1.3/pr0ps-trackmap-panel-2.1.3.zip plugins install pr0ps-trackmap-panel && \
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.4 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
     grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
 


### PR DESCRIPTION
2.1.4 is released on official grafana plugin repo now. Let's use it again.

_Note: 2.1.4 does not contain any functional changes, just metadata changes._