### PR TITLE
Add composite index to position : drive_id + date instead of drive_id

### DIFF
--- a/priv/repo/migrations/20230417225712_composite_index_to_position.exs
+++ b/priv/repo/migrations/20230417225712_composite_index_to_position.exs
@@ -1,0 +1,8 @@
+defmodule TeslaMate.Repo.Migrations.AddCompositeIndexToPositions do
+  use Ecto.Migration
+
+  def change do
+    create index(:positions, [:drive_id, :date])
+    drop index(:positions, [:drive_id])
+  end
+end


### PR DESCRIPTION
This is a proposed fix to the #2278 issue. On my setup with 5 million records in the position table, the close_drive function executes in under 7 seconds from 55 seconds before the index change.
An (untested) alternative fix would be to change the queries in the close_drive function like this:
```
    filtered_positions =
      from p in Position,
        where:
          p.drive_id == ^id and
            not is_nil(p.ideal_battery_range_km) and
            not is_nil(p.odometer)

    non_streamed_drive_data =
      from p in subquery(filtered_positions),
        select: %{
          start_ideal_range_km: first_value(p.ideal_battery_range_km) |> over(:w),
          end_ideal_range_km: last_value(p.ideal_battery_range_km) |> over(:w),
          start_rated_range_km: first_value(p.rated_battery_range_km) |> over(:w),
          end_rated_range_km: last_value(p.rated_battery_range_km) |> over(:w)
        },
        windows: [
          w: [
            order_by:
              fragment("? RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", p.date)
          ]
        ],
        limit: 1
```
The idea here is to pre-filter to work with a subset of the positions table (drive_id = id) instead of the whole table.