### PR TITLE
Update drive-details.json missing dataSource for pressure units

### DIFF
--- a/grafana/dashboards/internal/drive-details.json
+++ b/grafana/dashboards/internal/drive-details.json
@@ -1950,6 +1950,7 @@
           "text": "bar",
           "value": "bar"
         },
+        "datasource": "TeslaMate",
         "definition": "select unit_of_pressure from settings limit 1;",
         "hide": 2,
         "includeAll": false,


### PR DESCRIPTION
Update drive-details.json missing dataSource for pressure units.

I have to fix this dashboard after every Grafana restart (upgrade) as it pull the latest of the dashboard and bring unfixed version down.