### PR TITLE
Show all vehicles on drive stats dashboard

### DIFF
--- a/grafana/dashboards/drive-stats.json
+++ b/grafana/dashboards/drive-stats.json
@@ -1039,8 +1039,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars ORDER BY display_priority ASC, name ASC;",

--- a/grafana/dashboards/efficiency.json
+++ b/grafana/dashboards/efficiency.json
@@ -1052,8 +1052,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars ORDER BY display_priority ASC, name ASC;",

--- a/grafana/dashboards/projected-range.json
+++ b/grafana/dashboards/projected-range.json
@@ -577,8 +577,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "TeslaMate",
         "definition": "SELECT name AS __text, id AS __value FROM cars ORDER BY display_priority ASC, name ASC;",


### PR DESCRIPTION
Only one Tesla is shown on the "Drive stats" dashboard. This is a simple fix to show each and every tesla on this dashboard. 
_Edit: same for efficiency and projected range dashboards_

Before:
<img width="492" alt="image" src="https://github.com/adriankumpf/teslamate/assets/573120/40761152-a5cd-46fd-977d-9a22179ea12e">

After:
<img width="502" alt="image" src="https://github.com/adriankumpf/teslamate/assets/573120/b2f7b1c3-056c-4aa0-bca1-fa9674457df2">
