### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -138,7 +138,7 @@ function createMap(opts) {
   const map = new M(opts.elId != null ? `map_${opts.elId}` : "map", opts);
 
   const osm = new TileLayer(
-    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     { maxZoom: 19 }
   );
 


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737

cc: @adriankumpf 