### PR TITLE
Cleanup Grafana Docker Container

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,10 +1,10 @@
-FROM grafana/grafana:9.5.3
+FROM grafana/grafana:9.5.13
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     GF_AUTH_ANONYMOUS_ENABLED=false \
     GF_AUTH_BASIC_ENABLED=false \
     GF_PATHS_PLUGINS="/var/lib/grafana-plugins" \
-    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel,natel-plotly-panel \
+    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=nline-plotlyjs-panel \
     GF_SECURITY_ADMIN_PASSWORD=admin \
     GF_SECURITY_ADMIN_USER=admin \
     GF_SECURITY_ALLOW_EMBEDDING=true \
@@ -20,9 +20,7 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 
 USER grafana
 
-RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install pr0ps-trackmap-panel 2.1.4 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install natel-plotly-panel 0.0.7 && \
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" --pluginUrl https://github.com/panodata/panodata-map-panel/releases/download/0.16.0/panodata-map-panel-0.16.0.zip plugins install grafana-worldmap-panel-ng
+RUN grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install nline-plotlyjs-panel 1.6.0
 
 COPY logo.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY favicon.png /usr/share/grafana/public/img/fav32.png


### PR DESCRIPTION
This removed several Plugins based on AngularJS as alternatives are available (geomap (in core) and nline-plotlyjs-panel)

This requires migrating some Dashboards over to the newer Panels. Happy to contribute if there is interest in catching up with latest grafana development