### PR TITLE
update tesla-youq project

### DIFF
--- a/website/docs/projects.md
+++ b/website/docs/projects.md
@@ -73,7 +73,7 @@ LINK: [Wiki How-To](https://github.com/alandtse/tesla/wiki/Teslamate-MQTT-Integr
 
 A lightweight app that will operate your smart garage door openers based on the location of your Tesla vehicles, automatically closing when you leave, and opening when you return. Supports multiple geofence types including circular, TeslaMate, and polygonal. Supports multiple vehicles and various smart garage door openers.
 
-LINK: [https://github.com/brchri/tesla-youq](https://github.com/brchri/tesla-geogdo)
+LINK: [https://github.com/brchri/tesla-geogdo](https://github.com/brchri/tesla-geogdo)
 
 ## [TeslaBox](https://www.teslarpi.com)
 


### PR DESCRIPTION
Due to MyQ restricting access to the MyQ API by 3rd parties, the Tesla-YouQ project has been deprecated and forked to Tesla-GeoGDO, which will continue the project for other smart garage door openers.