### PR TITLE
docs: bump Traefik to v3.5 and enable http3 in advanced guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - docs(dev): provide guidelines for checking dependency updates before merging (#4969 - @JakobLichterfeld)
 - docs: add domain prefix to Home Assistant default_entity_id (#5014 - @gym22)
 - docs: add star history (#5024 - @JakobLichterfeld)
+- docs: bump Traefik to v3.5 and enable http3 in advanced guide (#5023 - @swiffer)
 
 ## [2.1.1] - 2025-08-16
 


### PR DESCRIPTION
- upgrade traefik image tag to v3.5
- removes websocket config - it's working out of the box: https://doc.traefik.io/traefik/user-guides/websocket/#basic-websocket-configuration
- enables http/3

Fixes #5002 