### PR TITLE
fix(website): Bump node-forge to 1.3.3 to resolve CVE-2025-12816, CVE-2025-66030 and CVE-2025-66031

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12599,9 +12599,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^19.1.1"
   },
   "overrides": {
-    "webpack-dev-server": "^5.2.1"
+    "webpack-dev-server": "^5.2.1",
+    "node-forge": "^1.3.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Resolves a security vulnerability in the transitive dependency `node-forge` by bumping the version to 1.3.3.

An override has been added to `package.json` to enforce this version.

Closes https://github.com/teslamate-org/teslamate/security/dependabot/79 
Closes https://github.com/teslamate-org/teslamate/security/dependabot/80 
Closes https://github.com/teslamate-org/teslamate/security/dependabot/81