### PR TITLE
fix: remove reference to legacy pkgs.system

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,7 +5,7 @@
 , ...
 }:
 let
-  teslamate = self.packages.${pkgs.system}.default;
+  teslamate = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
   cfg = config.services.teslamate;
 
   inherit (lib)


### PR DESCRIPTION
This is the one and only reference I could find so far...