### PR TITLE
fix(vehicle): update state transition to handle offline scenario after a drive end with no network

### DIFF
--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1017,7 +1017,7 @@ defmodule TeslaMate.Vehicles.Vehicle do
         {:driving, {:offline, _last}, nil},
         %Data{} = data
       ) do
-    {:keep_state, %{data | last_used: DateTime.utc_now()}, schedule_fetch(30, data)}
+    {:next_state, :start, %Data{data | last_used: DateTime.utc_now()}, schedule_fetch(data)}
   end
 
   def handle_event(


### PR DESCRIPTION

What happens when a vehicle is in an underground parking garage, [I've noticed](https://github.com/teslamate-org/teslamate/issues/5067#issuecomment-3938543417) that the drive completes correctly but the status is still online and the requests continue to run every 30 seconds :

1. The vehicle transitions to `{:driving, {:unavailable, 0}, drive}` → incrementing `n` every 5 seconds.
1. After `n=15` (75 seconds), it transitions to `{:driving, {:offline, last}, drive}`.
1. After 15 minutes (`@drive_timeout_min`), `timeout_drive` closes the trip → transitions to `{:driving, {:offline, last}, nil}`.
1. From this point on, `{:keep_state}` loops every 30 seconds → never transitions to `:offline`.

The fix: when the trip has already been closed (`drive = nil`) and offline responses are still being received, it must switch to `:start` for the normal offline cycle to begin.

I have also updated the "times out a drive" test to reflect this change, and I have added a specific regression test for the underground parking scenario to ensure that this case is handled correctly in the future.