### PR TITLE
chore(website): bump mimimatch to version 3.1.5 to solve CVE-2026-26996, CVE-2026-27903 and CVE-2026-27904

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ We believe this step is necessary to protect the project from exploitation and t
 - build(deps): update flake.lock (#5148)
 - build(deps): update flake.lock (#5154)
 - build(deps): bump ajv in /website (#5149)
-- chore(website): bump mimimatch to version 3.1.4 to solve CVE-2026-26996, CVE-2026-27903 and CVE-2026-27904 (#5155 - @JakobLichterfeld)
+- chore(website): bump mimimatch to version 3.1.5 to solve CVE-2026-26996, CVE-2026-27903 and CVE-2026-27904 (#5155 - @JakobLichterfeld)
 
 #### Dashboards
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12481,9 +12481,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "webpack-dev-server": "^5.2.1",
     "node-forge": "^1.3.3",
     "qs": "^6.14.1",
-    "minimatch": "^3.1.4"
+    "minimatch": "^3.1.5"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
closes: https://github.com/teslamate-org/teslamate/security/dependabot/94, https://github.com/teslamate-org/teslamate/security/dependabot/95 and https://github.com/teslamate-org/teslamate/security/dependabot/96