### PR TITLE
feat(webview): Sort vehicles by display_priority

### DIFF
--- a/lib/teslamate/log/car.ex
+++ b/lib/teslamate/log/car.ex
@@ -19,6 +19,7 @@ defmodule TeslaMate.Log.Car do
     field :vid, :integer
     # TODO: with v2.0 mark as non nullable
     field :vin, :string
+    field :display_priority, :integer
 
     belongs_to :settings, CarSettings
 

--- a/lib/teslamate/vehicles.ex
+++ b/lib/teslamate/vehicles.ex
@@ -22,7 +22,9 @@ defmodule TeslaMate.Vehicles do
       timeout: 5000
     )
     |> Enum.map(fn {:ok, vehicle} -> vehicle end)
-    |> Enum.sort_by(fn %Vehicle.Summary{car: %Car{id: id}} -> id end)
+    |> Enum.sort_by(fn %Vehicle.Summary{car: %Car{id: id, display_priority: dp}} ->
+      {dp, id}
+    end)
   end
 
   def kill do


### PR DESCRIPTION
#5185

#### What does this PR do?
This PR updates the vehicle sorting logic in the Elixir backend so that the main TeslaMate Web UI respects the `display_priority` database column. Vehicles are now sorted by their assigned priority first (lowest number first), with the database `id` acting as a secondary tie-breaker.

#### Motivation
Currently, users can update the `display_priority` of their cars in the PostgreSQL database to control the order in which they appear in the Grafana dashboard dropdown menus. However, the TeslaMate web UI ignores this setting and strictly orders cars by their database `id` (the order they were added).

This PR bridges that gap, ensuring that the vehicle ordering is completely consistent across both Grafana and the web dashboard.

#### Implementation Details:
- `lib/teslamate/log/car.ex`: Mapped the existing `display_priority` database column to the `Car` Ecto schema (`field :display_priority, :integer`) so it is accessible within the application's structs.
- `lib/teslamate/vehicles.ex`: Updated the sorting pipeline in `list/0` for the `%Vehicle.Summary{}` structs. Leveraged deep pattern matching to extract the newly available property and sort using a tuple: `{display_priority, id}`.
- **Safety & Fallbacks:** Relies on Elixir's native term sorting behavior where numbers sort before nil. If a vehicle does not have a `display_priority` assigned, it safely falls to the bottom of the list.

#### Testing Performed
- Tested locally against a populated database with multiple vehicles.
- Verified that updating a vehicle's `display_priority` successfully reorders it in the UI.
- Verified that vehicles with identical priorities gracefully fall back to `id` sorting.