### PR TITLE
feat(webview): Sort vehicles by display_priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements and bug fixes
 
+- feat(webview): Sort vehicles by display_priority (#5188 - @olsoybakk and @swiffer)
+
 #### Build, CI, internal
 
 - build(deps): bump ex_cldr from 2.46.0 to 2.47.1 to fix 100% CPU lock when accessing TeslaMate web (#5166)

--- a/lib/teslamate/log/car.ex
+++ b/lib/teslamate/log/car.ex
@@ -19,6 +19,7 @@ defmodule TeslaMate.Log.Car do
     field :vid, :integer
     # TODO: with v2.0 mark as non nullable
     field :vin, :string
+    field :display_priority, :integer
 
     belongs_to :settings, CarSettings
 
@@ -43,7 +44,8 @@ defmodule TeslaMate.Log.Car do
       :marketing_name,
       :exterior_color,
       :wheel_type,
-      :spoiler_type
+      :spoiler_type,
+      :display_priority
     ])
     |> validate_required([:eid, :vid, :vin])
     |> unique_constraint(:settings_id)

--- a/lib/teslamate/vehicles.ex
+++ b/lib/teslamate/vehicles.ex
@@ -22,7 +22,9 @@ defmodule TeslaMate.Vehicles do
       timeout: 5000
     )
     |> Enum.map(fn {:ok, vehicle} -> vehicle end)
-    |> Enum.sort_by(fn %Vehicle.Summary{car: %Car{id: id}} -> id end)
+    |> Enum.sort_by(fn %Vehicle.Summary{car: %Car{id: id, display_priority: dp}} ->
+      {dp, id}
+    end)
   end
 
   def kill do

--- a/test/teslamate/log/log_car_test.exs
+++ b/test/teslamate/log/log_car_test.exs
@@ -14,7 +14,8 @@ defmodule TeslaMate.LogCarTest do
     vin: "12345F",
     exterior_color: "White",
     spoiler_type: "None",
-    wheel_type: "AeroTurbine19"
+    wheel_type: "AeroTurbine19",
+    display_priority: 1
   }
   @update_attrs %{
     efficiency: 0.190,
@@ -26,7 +27,8 @@ defmodule TeslaMate.LogCarTest do
     vin: "6789R",
     exterior_color: "MetallicBlack",
     spoiler_type: "Passive",
-    wheel_type: "AeroTurbine20"
+    wheel_type: "AeroTurbine20",
+    display_priority: 2
   }
   @invalid_attrs %{
     efficiency: nil,
@@ -50,7 +52,7 @@ defmodule TeslaMate.LogCarTest do
     car
   end
 
-  test "list_cars/0 returns all car" do
+  test "list_cars/0 returns all cars" do
     car = car_fixture()
     assert Log.list_cars() |> Enum.map(&Repo.preload(&1, :settings)) == [car]
   end
@@ -78,6 +80,7 @@ defmodule TeslaMate.LogCarTest do
     assert car.exterior_color == "White"
     assert car.spoiler_type == "None"
     assert car.wheel_type == "AeroTurbine19"
+    assert car.display_priority == 1
   end
 
   test "create_or_update_car/1 with invalid data returns error changeset" do
@@ -111,6 +114,7 @@ defmodule TeslaMate.LogCarTest do
     assert car.exterior_color == "MetallicBlack"
     assert car.spoiler_type == "Passive"
     assert car.wheel_type == "AeroTurbine20"
+    assert car.display_priority == 2
   end
 
   test "create_or_update_car/2 with invalid data returns error changeset" do


### PR DESCRIPTION
taken from #5184 to build GHCR images and test from inside the repo - credits to @olsoybakk!

#### What does this PR do?
This PR updates the vehicle sorting logic in the Elixir backend so that the main TeslaMate Web UI respects the `display_priority` database column. Vehicles are now sorted by their assigned priority first (lowest number first), with the database `id` acting as a secondary tie-breaker.

#### Motivation
Currently, users can update the `display_priority` of their cars in the PostgreSQL database to control the order in which they appear in the Grafana dashboard dropdown menus. However, the TeslaMate web UI ignores this setting and strictly orders cars by their database `id` (the order they were added).

This PR bridges that gap, ensuring that the vehicle ordering is completely consistent across both Grafana and the web dashboard.

#### Implementation Details:
- `lib/teslamate/log/car.ex`: Mapped the existing `display_priority` database column to the `Car` Ecto schema (`field :display_priority, :integer`) so it is accessible within the application's structs.
- `lib/teslamate/vehicles.ex`: Updated the sorting pipeline in `list/0` for the `%Vehicle.Summary{}` structs. Leveraged deep pattern matching to extract the newly available property and sort using a tuple: `{display_priority, id}`.
- **Safety & Fallbacks:** Relies on Elixir's native term sorting behavior where numbers sort before nil. If a vehicle does not have a `display_priority` assigned, it safely falls to the bottom of the list.

#### Testing Performed
- Tested locally against a populated database with multiple vehicles.
- Verified that updating a vehicle's `display_priority` successfully reorders it in the UI.
- Verified that vehicles with identical priorities gracefully fall back to `id` sorting.