### PR TITLE
ci: Migrate BuildJet runners to native ARM runners

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -35,10 +35,10 @@ jobs:
             runs_on: "ubuntu-24.04"
             cache_id: amd64
           - platform: "linux/arm/v7"
-            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+            runs_on: "ubuntu-24.04-arm"
             cache_id: arm
           - platform: "linux/arm64"
-            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+            runs_on: "ubuntu-24.04-arm"
             cache_id: arm64
 
     runs-on: ${{ matrix.runs_on }}

--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -57,10 +57,10 @@ jobs:
             runs_on: "ubuntu-24.04"
             cache_id: amd64
           - platform: "linux/arm/v7"
-            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+            runs_on: "ubuntu-24.04-arm"
             cache_id: arm
           - platform: "linux/arm64"
-            runs_on: "buildjet-2vcpu-ubuntu-2204-arm"
+            runs_on: "ubuntu-24.04-arm"
             cache_id: arm64
 
     runs-on: ${{ matrix.runs_on }}


### PR DESCRIPTION
 BuildJet for GitHub Actions shuts down on March 31st, 2026 ([blog post](https://buildjet.com/for-github-actions/blog/we-are-shutting-down)).

For ARM workflows, they recommend migrating to the native ARM runners GitHub now offers.
