### PR TITLE
ci: ensure not running 2 workflows when pushing to a branch that has a PR open

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -16,6 +16,11 @@ on:
       - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
 
+# Avoid running multiple concurrent workflows for the same branch or PR, and cancel any in-progress runs when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - build(deps): bump ex_cldr from 2.46.0 to 2.47.1 to fix 100% CPU lock when accessing TeslaMate web (#5166)
 - ci: migrate runners for arm from buildjet to gha native (#5206 - @adriankumpf)
+- ci: ensure not running 2 workflows when pushing to a branch that has a PR open (#5209 - @swiffer)
 
 #### Dashboards
 


### PR DESCRIPTION
the DevOps workflow is currently triggered on push an pr - this triggers multiple runs for branches that have a PR open.

I assume we want to keep the DevOps workflow for both. to avoid running it twice I've added concurrency configuration which cancels the workflow triggered by the push and allows the one triggered by updating the pr to run through.

In addition this will cancel any workflow runs still running if additional push events occure meanwhile.