### PR TITLE
ci: fix concurrency group in DevOps workflow

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -18,7 +18,7 @@ on:
 
 # Avoid running multiple concurrent workflows for the same branch or PR, and cancel any in-progress runs when a new commit is pushed
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
ensure to use source branch name (pull request) and fallback to branch name if not set (push)