### PR TITLE
ci: limit DevOps workflow runs of type push to branch main to prevent duplicate runs on PR

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -3,6 +3,7 @@ name: DevOps
 on:
   workflow_dispatch:
   push:
+    branches: ["main"]
     paths:
       - "**/*"
       - "!.github/**" # Important: Exclude PRs related to .github from auto-run
@@ -16,9 +17,9 @@ on:
       - "!.github/workflows/**" # Important: Exclude PRs related to .github/workflows from auto-run
       - "!.github/actions/**" # Important: Exclude PRs related to .github/actions from auto-run
 
-# Avoid running multiple concurrent workflows for the same branch or PR, and cancel any in-progress runs when a new commit is pushed
+# Cancel any in-progress runs when a new commit is pushed
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - build(deps): bump ex_cldr from 2.46.0 to 2.47.1 to fix 100% CPU lock when accessing TeslaMate web (#5166)
 - ci: migrate runners for arm from buildjet to gha native (#5206 - @adriankumpf)
-- ci: ensure not running 2 workflows when pushing to a branch that has a PR open (#5209 - @swiffer)
+- ci: limit DevOps workflow runs of type push to branch main to prevent duplicate runs on PR (#5211 - @swiffer)
 - build(deps): update flake.lock (#5186)
 - fix(nix): update mix dependency hash in nix builds (#5186 - @JakobLichterfeld)
 - build(deps): bump actions/stale from 10.1.1 to 10.2.0 (#5162)


### PR DESCRIPTION
Previous attemts (#5209 and #5210) to ensure not running the DevOps workflow twice for pushes to branches with existing PRs failed as workflows / jobs cancelled via concurrency settings count as failed.

- Limit the workflow to run on events of type PR targeting main and pushes to main instead.
- Keep Concurrency config for canceling any outdated workflow runs.