### PR TITLE
feat: add center display state and alerts for Sentry Mode

### DIFF
--- a/grafana/dashboards/display-state.json
+++ b/grafana/dashboards/display-state.json
@@ -1,0 +1,518 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "icon": "dashboard",
+      "tags": [],
+      "title": "TeslaMate",
+      "tooltip": "",
+      "type": "link",
+      "url": "${base_url:raw}"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "tags": [
+        "tesla"
+      ],
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "panels": [],
+      "repeat": "car_id",
+      "title": "$car_id",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Current center display state of the vehicle.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "text": "Off", "color": "dark-gray" },
+                "2": { "text": "On, standby or Camp Mode", "color": "dark-green" },
+                "3": { "text": "On, charging screen", "color": "dark-blue" },
+                "4": { "text": "On", "color": "green" },
+                "5": { "text": "On, Big charging screen", "color": "blue" },
+                "6": { "text": "On, Ready to unlock", "color": "dark-yellow" },
+                "7": { "text": "Sentry Mode", "color": "dark-red" },
+                "8": { "text": "Dog Mode", "color": "dark-orange" },
+                "9": { "text": "Media", "color": "dark-purple" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#c7d0d9", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "/^center_display_state$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT center_display_state\nFROM positions\nWHERE car_id = $car_id\n  AND center_display_state IS NOT NULL\nORDER BY date DESC\nLIMIT 1;",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Display State",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Sentry Mode activation events within the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(*) AS sentry_activations\nFROM (\n  SELECT date, center_display_state,\n    LAG(center_display_state) OVER (ORDER BY date) AS prev_state\n  FROM positions\n  WHERE car_id = $car_id\n    AND $__timeFilter(date)\n    AND center_display_state IS NOT NULL\n) sub\nWHERE center_display_state = 7 AND (prev_state IS NULL OR prev_state != 7);",
+          "refId": "A"
+        }
+      ],
+      "title": "Sentry Mode Activations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Time spent in Sentry Mode within the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "red", "value": 480 }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ROUND(EXTRACT(EPOCH FROM SUM(\n  LEAD(date) OVER (ORDER BY date) - date\n)) / 60.0, 1) AS sentry_minutes\nFROM positions\nWHERE car_id = $car_id\n  AND $__timeFilter(date)\n  AND center_display_state = 7;",
+          "refId": "A"
+        }
+      ],
+      "title": "Time in Sentry Mode (min)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Center display state over time. Hover to see state names.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": { "text": "Off" },
+                "2": { "text": "Standby/Camp" },
+                "3": { "text": "Charging screen" },
+                "4": { "text": "On" },
+                "5": { "text": "Big charging screen" },
+                "6": { "text": "Ready to unlock" },
+                "7": { "text": "Sentry Mode" },
+                "8": { "text": "Dog Mode" },
+                "9": { "text": "Media" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "mergeValues": true,
+        "showValue": "auto",
+        "alignValue": "left",
+        "rowHeight": 0.9
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__time(date),\n  center_display_state\nFROM positions\nWHERE car_id = $car_id\n  AND $__timeFilter(date)\n  AND center_display_state IS NOT NULL\nORDER BY date;",
+          "refId": "A"
+        }
+      ],
+      "title": "Display State Timeline",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Distribution of center display states within the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": { "text": "Off" },
+                "2": { "text": "Standby/Camp" },
+                "3": { "text": "Charging screen" },
+                "4": { "text": "On" },
+                "5": { "text": "Big charging screen" },
+                "6": { "text": "Ready to unlock" },
+                "7": { "text": "Sentry Mode" },
+                "8": { "text": "Dog Mode" },
+                "9": { "text": "Media" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "options": {
+        "displayLabels": ["name", "percent"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  CASE center_display_state\n    WHEN 0 THEN 'Off'\n    WHEN 2 THEN 'Standby/Camp Mode'\n    WHEN 3 THEN 'Charging screen'\n    WHEN 4 THEN 'On'\n    WHEN 5 THEN 'Big charging screen'\n    WHEN 6 THEN 'Ready to unlock'\n    WHEN 7 THEN 'Sentry Mode'\n    WHEN 8 THEN 'Dog Mode'\n    WHEN 9 THEN 'Media'\n    ELSE 'Unknown (' || center_display_state || ')'\n  END AS state,\n  COUNT(*) AS count\nFROM positions\nWHERE car_id = $car_id\n  AND $__timeFilter(date)\n  AND center_display_state IS NOT NULL\nGROUP BY center_display_state\nORDER BY count DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Display State Distribution",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "TeslaMate"
+      },
+      "description": "Recent Sentry Mode activation events.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "duration_min" },
+            "properties": [
+              { "id": "unit", "value": "m" },
+              { "id": "displayName", "value": "Duration" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "started_at" },
+            "properties": [
+              { "id": "unit", "value": "dateTimeAsLocal" },
+              { "id": "displayName", "value": "Started" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ended_at" },
+            "properties": [
+              { "id": "unit", "value": "dateTimeAsLocal" },
+              { "id": "displayName", "value": "Ended" }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          { "desc": true, "displayName": "Started" }
+        ]
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "TeslaMate"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH sentry_events AS (\n  SELECT date,\n    center_display_state,\n    LAG(center_display_state) OVER (ORDER BY date) AS prev_state,\n    LEAD(date) OVER (ORDER BY date) AS next_date,\n    LEAD(center_display_state) OVER (ORDER BY date) AS next_state\n  FROM positions\n  WHERE car_id = $car_id\n    AND $__timeFilter(date)\n    AND center_display_state IS NOT NULL\n)\nSELECT\n  s.date AS started_at,\n  MIN(e.date) AS ended_at,\n  ROUND(EXTRACT(EPOCH FROM (MIN(e.date) - s.date)) / 60.0, 1) AS duration_min\nFROM sentry_events s\nLEFT JOIN sentry_events e\n  ON e.date > s.date AND e.center_display_state != 7\nWHERE s.center_display_state = 7\n  AND (s.prev_state IS NULL OR s.prev_state != 7)\nGROUP BY s.date\nORDER BY s.date DESC\nLIMIT 50;",
+          "refId": "A"
+        }
+      ],
+      "title": "Sentry Mode Events",
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 42,
+  "tags": [
+    "tesla"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "TeslaMate"
+        },
+        "definition": "SELECT\n    id as __value,\n    CASE WHEN COUNT(id) OVER (PARTITION BY name) > 1 AND name IS NOT NULL THEN CONCAT(name, ' - ', RIGHT(vin, 6)) ELSE COALESCE(name, CONCAT('VIN ', vin)) end as __text \nFROM cars\nORDER BY display_priority ASC, name ASC, vin ASC;",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Car",
+        "name": "car_id",
+        "options": [],
+        "query": "SELECT\n    id as __value,\n    CASE WHEN COUNT(id) OVER (PARTITION BY name) > 1 AND name IS NOT NULL THEN CONCAT(name, ' - ', RIGHT(vin, 6)) ELSE COALESCE(name, CONCAT('VIN ', vin)) end as __text \nFROM cars\nORDER BY display_priority ASC, name ASC, vin ASC;",
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "TeslaMate"
+        },
+        "definition": "select base_url from settings limit 1;",
+        "hide": 2,
+        "includeAll": false,
+        "name": "base_url",
+        "options": [],
+        "query": "select base_url from settings limit 1;",
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Display State",
+  "uid": "center-display-state",
+  "version": 1,
+  "weekStart": ""
+}

--- a/lib/teslamate/log/position.ex
+++ b/lib/teslamate/log/position.ex
@@ -33,6 +33,7 @@ defmodule TeslaMate.Log.Position do
     field :tpms_pressure_fr, :decimal
     field :tpms_pressure_rl, :decimal
     field :tpms_pressure_rr, :decimal
+    field :center_display_state, :integer
 
     belongs_to(:car, Car)
     belongs_to(:drive, Drive)
@@ -69,7 +70,8 @@ defmodule TeslaMate.Log.Position do
       :tpms_pressure_fl,
       :tpms_pressure_fr,
       :tpms_pressure_rl,
-      :tpms_pressure_rr
+      :tpms_pressure_rr,
+      :center_display_state
     ])
     |> validate_required([:car_id, :date, :latitude, :longitude])
     |> foreign_key_constraint(:car_id)

--- a/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
+++ b/lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex
@@ -67,6 +67,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       |> add_geofence(summary)
       |> add_active_route(summary)
 
+    maybe_alert_sentry_mode(summary, state)
     publish_values(values, state)
     {:noreply, %{state | last_values: values}}
   end
@@ -112,6 +113,7 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
     model trim_badging exterior_color wheel_type spoiler_type trunk_open frunk_open elevation power
     charge_current_request charge_current_request_max tpms_pressure_fl tpms_pressure_fr tpms_pressure_rl tpms_pressure_rr
     tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode center_display_state
+    center_display_state_name
   )a
 
   defp add_simple_values(map, %Summary{} = summary) do
@@ -197,6 +199,13 @@ defmodule TeslaMate.Mqtt.PubSub.VehicleSubscriber do
       active_route: active_route
     })
   end
+
+  defp maybe_alert_sentry_mode(%Summary{center_display_state: 7, display_name: name}, %State{last_values: last})
+       when is_nil(last) or :erlang.map_get(:center_display_state, last) != 7 do
+    Logger.warning("[Vehicle: #{name}] Sentry Mode activated (center_display_state: 7)")
+  end
+
+  defp maybe_alert_sentry_mode(_summary, _state), do: :ok
 
   defp publish({key, value}, %State{car_id: car_id, namespace: namespace, deps: deps}) do
     topic =

--- a/lib/teslamate/vehicles/vehicle.ex
+++ b/lib/teslamate/vehicles/vehicle.ex
@@ -1390,7 +1390,8 @@ defmodule TeslaMate.Vehicles.Vehicle do
       tpms_pressure_fl: vehicle.vehicle_state.tpms_pressure_fl,
       tpms_pressure_fr: vehicle.vehicle_state.tpms_pressure_fr,
       tpms_pressure_rl: vehicle.vehicle_state.tpms_pressure_rl,
-      tpms_pressure_rr: vehicle.vehicle_state.tpms_pressure_rr
+      tpms_pressure_rr: vehicle.vehicle_state.tpms_pressure_rr,
+      center_display_state: vehicle.vehicle_state.center_display_state
     }
 
     elevation =

--- a/lib/teslamate/vehicles/vehicle/summary.ex
+++ b/lib/teslamate/vehicles/vehicle/summary.ex
@@ -18,7 +18,7 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
     tpms_soft_warning_fl tpms_soft_warning_fr tpms_soft_warning_rl tpms_soft_warning_rr climate_keeper_mode
     active_route_destination active_route_latitude active_route_longitude active_route_energy_at_arrival
     active_route_miles_to_arrival active_route_minutes_to_arrival active_route_traffic_minutes_delay
-    center_display_state
+    center_display_state center_display_state_name
   )a
 
   def into(nil, %{state: :start, healthy?: healthy?, car: car}) do
@@ -149,9 +149,22 @@ defmodule TeslaMate.Vehicles.Vehicle.Summary do
       tpms_soft_warning_fr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_fr]),
       tpms_soft_warning_rl: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rl]),
       tpms_soft_warning_rr: get_in_struct(vehicle, [:vehicle_state, :tpms_soft_warning_rr]),
-      center_display_state: get_in_struct(vehicle, [:vehicle_state, :center_display_state])
+      center_display_state: get_in_struct(vehicle, [:vehicle_state, :center_display_state]),
+      center_display_state_name:
+        center_display_state_name(get_in_struct(vehicle, [:vehicle_state, :center_display_state]))
     }
   end
+
+  defp center_display_state_name(0), do: "Off"
+  defp center_display_state_name(2), do: "On, standby or Camp Mode"
+  defp center_display_state_name(3), do: "On, charging screen"
+  defp center_display_state_name(4), do: "On"
+  defp center_display_state_name(5), do: "On, Big charging screen"
+  defp center_display_state_name(6), do: "On, Ready to unlock"
+  defp center_display_state_name(7), do: "Sentry Mode"
+  defp center_display_state_name(8), do: "Dog Mode"
+  defp center_display_state_name(9), do: "Media"
+  defp center_display_state_name(_), do: nil
 
   defp charge(vehicle, key), do: get_in_struct(vehicle, [:charge_state, key])
 

--- a/lib/teslamate_web/live/car_live/summary.html.heex
+++ b/lib/teslamate_web/live/car_live/summary.html.heex
@@ -124,13 +124,36 @@
             <span class="mdi mdi-shield-check"></span>
           </span>
         <% end %>
-        <%= if @summary.center_display_state == 7 do %>
-          <span
-            class="icon has-text-inherit has-tooltip-top has-tooltip-left-mobile"
-            data-tooltip={gettext("Sentry Mode recording")}
-          >
-            <span class="mdi mdi-cctv"></span>
-          </span>
+        <%= case @summary.center_display_state do %>
+          <% 7 -> %>
+            <span
+              class="icon has-text-danger has-tooltip-top has-tooltip-left-mobile"
+              data-tooltip={gettext("Sentry Mode")}
+            >
+              <span class="mdi mdi-cctv"></span>
+            </span>
+          <% 8 -> %>
+            <span
+              class="icon has-text-warning has-tooltip-top has-tooltip-left-mobile"
+              data-tooltip={gettext("Dog Mode")}
+            >
+              <span class="mdi mdi-dog-side"></span>
+            </span>
+          <% 9 -> %>
+            <span
+              class="icon has-text-inherit has-tooltip-top has-tooltip-left-mobile"
+              data-tooltip={gettext("Media")}
+            >
+              <span class="mdi mdi-music"></span>
+            </span>
+          <% 2 -> %>
+            <span
+              class="icon has-text-inherit has-tooltip-top has-tooltip-left-mobile"
+              data-tooltip={gettext("Camp Mode")}
+            >
+              <span class="mdi mdi-tent"></span>
+            </span>
+          <% _ -> %>
         <% end %>
         <%= unless is_nil(@summary.locked) do %>
           <span

--- a/priv/repo/migrations/20260415120000_add_center_display_state_to_positions.exs
+++ b/priv/repo/migrations/20260415120000_add_center_display_state_to_positions.exs
@@ -1,0 +1,9 @@
+defmodule TeslaMate.Repo.Migrations.AddCenterDisplayStateToPositions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:positions) do
+      add :center_display_state, :smallint
+    end
+  end
+end


### PR DESCRIPTION
## Add center display state tracking with Sentry Mode alerts and Grafana dashboard

Adds full support for the Tesla `center_display_state` field — from API parsing through database persistence, MQTT publishing, UI display, and Grafana visualization.

### What does `center_display_state` tell us?

| Value | Meaning |
|-------|---------|
| 0 | Off |
| 2 | On, standby or Camp Mode |
| 3 | On, charging screen |
| 4 | On |
| 5 | On, Big charging screen |
| 6 | On, Ready to unlock |
| 7 | Sentry Mode |
| 8 | Dog Mode |
| 9 | Media |

### Changes

#### MQTT
- New topic `teslamate/cars/$car_id/center_display_state_name` publishes the human-readable state name (e.g. `"Sentry Mode"`, `"Dog Mode"`)
- Logs a warning on Sentry Mode activation (`center_display_state` transitions to `7`), enabling log-based alerting

#### Web UI
- Enhanced vehicle summary icons for multiple display states:
  - 🔴 **Sentry Mode** — CCTV icon (red)
  - 🟠 **Dog Mode** — dog icon (yellow)
  - 🎵 **Media** — music icon
  - ⛺ **Camp Mode** — tent icon

#### Database
- New migration adds `center_display_state` (smallint) to the `positions` table
- Field is persisted on every position record for historical analysis

#### Grafana
- New **Display State** dashboard with 6 panels:
  - **Current Display State** — color-coded stat showing live state
  - **Sentry Mode Activations** — count of sentry mode transitions in time range
  - **Time in Sentry Mode** — total minutes spent in sentry mode
  - **Display State Timeline** — state-timeline visualization over time
  - **Display State Distribution** — donut chart of time per state
  - **Sentry Mode Events** — table of sentry sessions with start/end times and duration

### Files Changed

- `lib/teslamate/vehicles/vehicle/summary.ex` — added `center_display_state_name` field + mapping function
- `lib/teslamate/mqtt/pubsub/vehicle_subscriber.ex` — publish new MQTT topic + sentry mode log alert
- `lib/teslamate_web/live/car_live/summary.html.heex` — display state icons in UI
- `lib/teslamate/log/position.ex` — schema + changeset for new column
- `lib/teslamate/vehicles/vehicle.ex` — persist `center_display_state` in position records
- `priv/repo/migrations/20260415120000_add_center_display_state_to_positions.exs` — DB migration
- `grafana/dashboards/display-state.json` — new Grafana dashboard

### How to use for notifications

Subscribe to the MQTT topic `teslamate/cars/1/center_display_state_name` in Home Assistant, Node-RED, or any MQTT client. Trigger automations when the value changes to `"Sentry Mode"` to send push notifications, emails, or other alerts.